### PR TITLE
Use python configparser

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pyhamcrest
 mock
 nose
+unidecode==1.0.23

--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -2,9 +2,10 @@
 # Copyright 2011-2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import ConfigParser
 from StringIO import StringIO
 
-from xivo import OrderedConf, xivo_helpers
+from xivo import xivo_helpers
 from xivo_dao import asterisk_conf_dao
 from xivo_dao.resources.ivr import dao as ivr_dao
 
@@ -107,8 +108,10 @@ class ExtensionsConf(object):
 
         if self.contextsconf is not None:
             # load context templates
-            conf = OrderedConf.OrderedRawConf(filename=self.contextsconf)
-            if conf.has_conflicting_section_names():
+            conf = ConfigParser.RawConfigParser()
+            try:
+                conf.read([self.contextsconf])
+            except ConfigParser.DuplicateSectionError:
                 raise ValueError("%s has conflicting section names" % self.contextsconf)
             if not conf.has_section('template'):
                 raise ValueError("Template section doesn't exist in %s" % self.contextsconf)


### PR DESCRIPTION
The python configparser is now ordered by default, no need to
use the backported hacked python 2.4 module.

See: https://www.python.org/dev/peps/pep-0372/