### PR TITLE
pjsip: add some options to the registration section

### DIFF
--- a/wazo_confgend/plugins/pjsip_conf.py
+++ b/wazo_confgend/plugins/pjsip_conf.py
@@ -12,6 +12,7 @@ from .pjsip_options import (
     auth_options,
     endpoint_options,
     global_options,
+    registration_options,
     system_options,
     transport_options,
 )
@@ -493,7 +494,16 @@ class SipDBExtractor(object):
             ('type', 'registration'),
         ]
 
+        # If the pjsip max_retries field is set use it, otherwise fallback to the migration else default
+        max_retries_chan_sip = self._general_settings_dict.pop('registerattempts')
+        if max_retries_chan_sip is not None:
+            self._general_settings_dict.setdefault(
+                'max_retries',
+                max_retries_chan_sip,
+            )
+
         self._add_from_mapping(fields, self.sip_general_to_register_tpl, self._general_settings_dict)
+        self._add_pjsip_options(fields, registration_options, self._general_settings_dict)
         outbound_proxy = self._general_settings_dict.get('outboundproxy')
         if outbound_proxy:
             self._add_option(fields, ('outbound_proxy', outbound_proxy))

--- a/wazo_confgend/plugins/pjsip_options.py
+++ b/wazo_confgend/plugins/pjsip_options.py
@@ -201,6 +201,13 @@ aor_options = [
     # 'voicemail_extension',
 ]
 
+registration_options = [
+    'auth_rejection_permanent',
+    'forbidden_retry_interval',
+    'fatal_retry_interval',
+    'max_retries',
+]
+
 system_options = [
     'timer_t1',
     'timer_b',


### PR DESCRIPTION
The goal is to be able to generate this configuration

```
[wazo-general-registration](!)
type = registration
retry_interval = 20
auth_rejection_permanent = off
forbidden_retry_interval = 30
fatal_retry_interval = 30
max_retries = 10000
```