### PR TITLE
Wazo 1435 none ascii ivr sound files

### DIFF
--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2011-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import copy
@@ -297,5 +297,4 @@ class ExtensionsConf(object):
         for ivr in ivr_dao.find_all_by():
             template_context = {'ivr': ivr}
             template = self._tpl_helper.get_customizable_template('asterisk/extensions/ivr', ivr.id)
-            template.generate(template_context, output)
-            print >> output
+            print >> output, template.dump(template_context)

--- a/wazo_confgend/generators/tests/test_extensionsconf.py
+++ b/wazo_confgend/generators/tests/test_extensionsconf.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2011-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
 import unittest
+import textwrap
 from StringIO import StringIO
 
 from hamcrest import assert_that, contains_string
@@ -50,13 +51,17 @@ class TestExtensionsConf(unittest.TestCase):
 
     @patch('wazo_confgend.generators.extensionsconf.ivr_dao')
     def test_generate_ivrs(self, mock_ivr_dao):
-        ivr = IVR(id=42, name='foo', menu_sound='hello-world')
+        ivr = IVR(id=42, name='foo', menu_sound=u'héllo-world')
         mock_ivr_dao.find_all_by.return_value = [ivr]
-        self.tpl_mapping['asterisk/extensions/ivr.jinja'] = '{{ ivr.id }}'
+        self.tpl_mapping['asterisk/extensions/ivr.jinja'] = textwrap.dedent('''
+            [xivo-ivr-{{ ivr.id }}]
+            same  =   n,Background({{ ivr.menu_sound }})
+        ''')
 
         self.extensionsconf._generate_ivr(self.output)
 
-        assert_that(self.output.getvalue(), contains_string('42'))
+        assert_that(self.output.getvalue(), contains_string('[xivo-ivr-42]'))
+        assert_that(self.output.getvalue(), contains_string(u'same  =   n,Background(héllo-world)'))
 
     @patch('wazo_confgend.generators.extensionsconf.ivr_dao')
     @patch('wazo_confgend.generators.extensionsconf.asterisk_conf_dao')

--- a/wazo_confgend/template.py
+++ b/wazo_confgend/template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from jinja2 import Environment
@@ -41,6 +41,3 @@ class _Template(object):
     def dump(self, context):
         # XXX do we encode in utf-8 ?
         return self._jinja_template.render(context)
-
-    def generate(self, context, output):
-        self._jinja_template.stream(context).dump(output, encoding='utf-8')

--- a/wazo_confgend/tests/test_template.py
+++ b/wazo_confgend/tests/test_template.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016 Proformatique Inc.
+# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from StringIO import StringIO
 from os.path import basename
 from unittest import TestCase
 
@@ -39,11 +38,3 @@ class TestTemplateHelper(TestCase):
         output = template.dump({'value': 'hello world'})
 
         assert_that(output, contains_string('hello world'))
-
-    def test_generate_template(self):
-        output = StringIO()
-        template = self.tpl_helper.get_template('foo')
-
-        template.generate({'value': 'hello world'}, output)
-
-        assert_that(output.getvalue(), contains_string('hello world'))


### PR DESCRIPTION
The problem here is that the current version mixes unicode and str in the StringIO object.

`template.generate` encodes the template in utf8 and adds it the StringIO which already contains unicode. the `template.dump` method already render the template without encoding it.