### PR TITLE
contexts: inherit BASE_EXTEN and BASE_CONTEXT variables

### DIFF
--- a/etc/wazo-confgend/templates/contexts.conf
+++ b/etc/wazo-confgend/templates/contexts.conf
@@ -15,8 +15,8 @@ exten = t,1,Hangup()
 exten = i,1,Playback(no-user-find)
 same  =   n,Hangup()
 
-objtpl = %%EXTEN%%,%%PRIORITY%%,Set(XIVO_BASE_CONTEXT=${CONTEXT})
-objtpl =                      n,Set(XIVO_BASE_EXTEN=${EXTEN})
+objtpl = %%EXTEN%%,%%PRIORITY%%,Set(__XIVO_BASE_CONTEXT=${CONTEXT})
+objtpl =                      n,Set(__XIVO_BASE_EXTEN=${EXTEN})
 objtpl =                      n,%%ACTION%%
 
 [type:incall]
@@ -38,19 +38,19 @@ same  =   n,Hangup()
 
 exten = _+.,1,Goto(${EXTEN:1},1)
 
-objtpl = %%EXTEN%%,%%PRIORITY%%,Set(XIVO_BASE_CONTEXT=${CONTEXT})
-objtpl =                      n,Set(XIVO_BASE_EXTEN=${EXTEN})
-objtpl =                      n,Set(WAZO_TENANT_UUID=%%TENANT_UUID%%)
+objtpl = %%EXTEN%%,%%PRIORITY%%,Set(__XIVO_BASE_CONTEXT=${CONTEXT})
+objtpl =                      n,Set(__XIVO_BASE_EXTEN=${EXTEN})
+objtpl =                      n,Set(__WAZO_TENANT_UUID=%%TENANT_UUID%%)
 objtpl =                      n,GotoIf(${XIVO_FROM_S}?:action)
 objtpl =                      n,CELGenUserEvent(XIVO_FROM_S)
 objtpl =                      n(action),%%ACTION%%
 
 [type:outcall]
-objtpl = %%EXTEN%%,%%PRIORITY%%,Set(XIVO_BASE_CONTEXT=${CONTEXT})
-objtpl =                      n,Set(XIVO_BASE_EXTEN=${EXTEN})
+objtpl = %%EXTEN%%,%%PRIORITY%%,Set(__XIVO_BASE_CONTEXT=${CONTEXT})
+objtpl =                      n,Set(__XIVO_BASE_EXTEN=${EXTEN})
 objtpl =                      n,%%ACTION%%
 
 [xivo-features]
-objtpl = %%EXTEN%%,%%PRIORITY%%,Set(XIVO_BASE_CONTEXT=${CONTEXT})
-objtpl =                      n,Set(XIVO_BASE_EXTEN=${EXTEN})
+objtpl = %%EXTEN%%,%%PRIORITY%%,Set(__XIVO_BASE_CONTEXT=${CONTEXT})
+objtpl =                      n,Set(__XIVO_BASE_EXTEN=${EXTEN})
 objtpl =                      n,%%ACTION%%

--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -241,8 +241,8 @@ class ExtensionsConf(object):
             if not xfeatures[fwdtype].get('commented', 1):
                 exten = xivo_helpers.clean_extension(xfeatures[fwdtype]['exten'])
                 cfeatures.extend([
-                    "%s,1,Set(XIVO_BASE_CONTEXT=${CONTEXT})" % exten,
-                    "%s,n,Set(XIVO_BASE_EXTEN=${EXTEN})" % exten,
+                    "%s,1,Set(__XIVO_BASE_CONTEXT=${CONTEXT})" % exten,
+                    "%s,n,Set(__XIVO_BASE_EXTEN=${EXTEN})" % exten,
                     "%s,n,Gosub(feature_forward,s,1(%s))\n" % (exten, x),
                 ])
 

--- a/wazo_confgend/generators/tests/expected_generated_extension.conf
+++ b/wazo_confgend/generators/tests/expected_generated_extension.conf
@@ -23,9 +23,9 @@ exten = _+.,1,Goto(${EXTEN:1},1)
 
 include = include-me.conf
 
-exten = foo@bar,1,Set(XIVO_BASE_CONTEXT=${CONTEXT})
-same  =     n,Set(XIVO_BASE_EXTEN=${EXTEN})
-same  =     n,Set(WAZO_TENANT_UUID=2b853b5b-6c19-4123-90da-3ce05fe9aa74)
+exten = foo@bar,1,Set(__XIVO_BASE_CONTEXT=${CONTEXT})
+same  =     n,Set(__XIVO_BASE_EXTEN=${EXTEN})
+same  =     n,Set(__WAZO_TENANT_UUID=2b853b5b-6c19-4123-90da-3ce05fe9aa74)
 same  =     n,GotoIf(${XIVO_FROM_S}?:action)
 same  =     n,CELGenUserEvent(XIVO_FROM_S)
 same  =     n(action),GoSub(did,s,1(incallfilter,))
@@ -34,8 +34,8 @@ exten = 4000,hint,confbridge:1
 exten = *7351***223*1234,hint,Custom:*7351***223*1234
 
 [xivo-features]
-exten = foo,1,Set(XIVO_BASE_CONTEXT=${CONTEXT})
-exten = foo,n,Set(XIVO_BASE_EXTEN=${EXTEN})
+exten = foo,1,Set(__XIVO_BASE_CONTEXT=${CONTEXT})
+exten = foo,n,Set(__XIVO_BASE_EXTEN=${EXTEN})
 exten = foo,n,Gosub(feature_forward,s,1(busy))
 
 [xivo-ivr-42]

--- a/wazo_confgend/generators/tests/test_extensionsconf.py
+++ b/wazo_confgend/generators/tests/test_extensionsconf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2011-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -28,11 +28,11 @@ class TestExtensionsConf(unittest.TestCase):
         self.output = StringIO()
 
     def test_generate_dialplan_from_template(self):
-        template = ["%%EXTEN%%,%%PRIORITY%%,Set('XIVO_BASE_CONTEXT': ${CONTEXT})"]
+        template = ["%%EXTEN%%,%%PRIORITY%%,Set('__XIVO_BASE_CONTEXT': ${CONTEXT})"]
         exten = {'exten': '*98', 'priority': 1}
         self.extensionsconf.gen_dialplan_from_template(template, exten, self.output)
 
-        self.assertEqual(self.output.getvalue(), "exten = *98,1,Set('XIVO_BASE_CONTEXT': ${CONTEXT})\n\n")
+        self.assertEqual(self.output.getvalue(), "exten = *98,1,Set('__XIVO_BASE_CONTEXT': ${CONTEXT})\n\n")
 
     def test_generate_hints(self):
         hints = [


### PR DESCRIPTION
Why:

* called party may want to know which extension was dialed, e.g. a user
with multiple DID