### PR TITLE
set pg application_name

### DIFF
--- a/etc/wazo-confgend/config.yml
+++ b/etc/wazo-confgend/config.yml
@@ -20,7 +20,7 @@ listen_port: 8669
 cache: /var/cache/wazo-confgend
 
 # Database connection informations.
-db_uri: postgresql://asterisk:proformatique@localhost/asterisk
+db_uri: postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-confgend
 
 # Templates location
 templates:

--- a/wazo_confgend/config.py
+++ b/wazo_confgend/config.py
@@ -18,7 +18,7 @@ _DEFAULT_CONFIG = {
     'cache': '/var/cache/wazo-confgend',
     'listen_address': '127.0.0.1',
     'listen_port': 8669,
-    'db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk',
+    'db_uri': 'postgresql://asterisk:proformatique@localhost/asterisk?application_name=wazo-confgend',
     'templates': {'contextsconf': '/etc/wazo-confgend/templates/contexts.conf'},
     'plugins': {},
 }


### PR DESCRIPTION
why: used for traceability
replace: https://github.com/wazo-platform/xivo-dao/pull/23