### PR TITLE
Pull request for WAZO-2518-meetings

### DIFF
--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -213,6 +213,7 @@ class ExtensionsConf(object):
 
         print >> options, self._extensions_features(conf, xfeatures)
         self._generate_ivr(output)
+        self._generate_meeting_guest(output)
 
         return options.getvalue()
 
@@ -287,4 +288,9 @@ class ExtensionsConf(object):
     def _generate_meeting_user(self, tenant_uuid, output):
         template_context = {'meetings': meeting_dao.find_all_by(tenant_uuid=tenant_uuid)}
         template = self._tpl_helper.get_template('asterisk/extensions/meeting-user')
+        print >> output, template.dump(template_context)
+
+    def _generate_meeting_guest(self, output):
+        template_context = {'meetings': meeting_dao.find_all_by()}
+        template = self._tpl_helper.get_template('asterisk/extensions/meeting-guest')
         print >> output, template.dump(template_context)

--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -10,6 +10,7 @@ from UserDict import DictMixin
 from xivo import xivo_helpers
 from xivo_dao import asterisk_conf_dao
 from xivo_dao.resources.ivr import dao as ivr_dao
+from xivo_dao.resources.meeting import dao as meeting_dao
 
 
 DEFAULT_EXTENFEATURES = {
@@ -208,6 +209,7 @@ class ExtensionsConf(object):
                 self.gen_dialplan_from_template(tmpl, exten, options)
 
             self._generate_hints(ctx['name'], options)
+            self._generate_meeting_user(ctx['tenant_uuid'], options)
 
         print >> options, self._extensions_features(conf, xfeatures)
         self._generate_ivr(output)
@@ -281,3 +283,8 @@ class ExtensionsConf(object):
             template_context = {'ivr': ivr}
             template = self._tpl_helper.get_customizable_template('asterisk/extensions/ivr', ivr.id)
             print >> output, template.dump(template_context)
+
+    def _generate_meeting_user(self, tenant_uuid, output):
+        template_context = {'meetings': meeting_dao.find_all_by(tenant_uuid=tenant_uuid)}
+        template = self._tpl_helper.get_template('asterisk/extensions/meeting-user')
+        print >> output, template.dump(template_context)

--- a/wazo_confgend/generators/tests/expected_generated_extension.conf
+++ b/wazo_confgend/generators/tests/expected_generated_extension.conf
@@ -44,3 +44,4 @@ exten = foo,n,Gosub(feature_forward,s,1(busy))
 [xivo-ivr-42]
 [xivo-ivr-43]
 
+[meeting-for-guests]...

--- a/wazo_confgend/generators/tests/expected_generated_extension.conf
+++ b/wazo_confgend/generators/tests/expected_generated_extension.conf
@@ -34,6 +34,8 @@ exten = 1000,hint,SIP/abcdef
 exten = 4000,hint,confbridge:1
 exten = *7351***223*1234,hint,Custom:*7351***223*1234
 
+exten = meeting-for-users...
+
 [xivo-features]
 exten = foo,1,Set(__XIVO_BASE_CONTEXT=${CONTEXT})
 exten = foo,n,Set(__XIVO_BASE_EXTEN=${EXTEN})

--- a/wazo_confgend/generators/tests/test_extensionsconf.py
+++ b/wazo_confgend/generators/tests/test_extensionsconf.py
@@ -99,6 +99,7 @@ class TestExtensionsConf(unittest.TestCase):
         ]
 
         self.tpl_mapping['asterisk/extensions/meeting-user.jinja'] = "exten = meeting-for-users..."
+        self.tpl_mapping['asterisk/extensions/meeting-guest.jinja'] = "[meeting-for-guests]..."
 
         self.extensionsconf.generate(self.output)
 

--- a/wazo_confgend/generators/tests/test_extensionsconf.py
+++ b/wazo_confgend/generators/tests/test_extensionsconf.py
@@ -63,9 +63,10 @@ class TestExtensionsConf(unittest.TestCase):
         assert_that(self.output.getvalue(), contains_string('[xivo-ivr-42]'))
         assert_that(self.output.getvalue(), contains_string(u'same  =   n,Background(héllo-world)'))
 
+    @patch('wazo_confgend.generators.extensionsconf.meeting_dao')
     @patch('wazo_confgend.generators.extensionsconf.ivr_dao')
     @patch('wazo_confgend.generators.extensionsconf.asterisk_conf_dao')
-    def test_generate(self, mock_asterisk_conf_dao, mock_ivr_dao):
+    def test_generate(self, mock_asterisk_conf_dao, mock_ivr_dao, mock_meeting_dao):
         hints = [
             'exten = 1000,hint,SIP/abcdef',
             'exten = 4000,hint,confbridge:1',
@@ -87,7 +88,7 @@ class TestExtensionsConf(unittest.TestCase):
         ]
 
         mock_asterisk_conf_dao.find_context_settings.return_value = [
-            {"name": "ctx_name", "contexttype": "incall"}
+            {"name": "ctx_name", "contexttype": "incall", "tenant_uuid": "tenant-uuid"}
         ]
         mock_asterisk_conf_dao.find_contextincludes_settings.return_value = [
             {"include": "include-me.conf"}
@@ -96,6 +97,8 @@ class TestExtensionsConf(unittest.TestCase):
             {"type": "incall", "context": "default", "exten": "foo@bar", "typeval":
              "incallfilter", "id": 1234, "tenant_uuid": "2b853b5b-6c19-4123-90da-3ce05fe9aa74"},
         ]
+
+        self.tpl_mapping['asterisk/extensions/meeting-user.jinja'] = "exten = meeting-for-users..."
 
         self.extensionsconf.generate(self.output)
 

--- a/wazo_confgend/hints/tests/test_adaptor.py
+++ b/wazo_confgend/hints/tests/test_adaptor.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
 import unittest
 
 from mock import Mock
-from hamcrest import assert_that, contains, contains_inanyorder, has_item
+from hamcrest import assert_that, contains_exactly, contains_inanyorder, has_item
 
 from wazo_confgend.hints.adaptor import (
     AgentAdaptor,
@@ -59,8 +59,8 @@ class TestUserSharedHintsAdaptor(TestAdaptor):
 
     def test_adaptor_generate_shared_user_hints(self):
         assert_that(self.adaptor.generate(), contains_inanyorder(
-            contains('83f38716-27d8-45c5-8fa6-5c7cb18acb26', 'PJSIP/abc&SCCP/1001'),
-            contains('0486beeb-4e3d-415b-b32d-660f44f6bab8', 'PJSIP/def&SCCP/1002'),
+            contains_exactly('83f38716-27d8-45c5-8fa6-5c7cb18acb26', 'PJSIP/abc&SCCP/1001'),
+            contains_exactly('0486beeb-4e3d-415b-b32d-660f44f6bab8', 'PJSIP/def&SCCP/1002'),
         ))
 
 
@@ -72,7 +72,7 @@ class TestConferenceAdaptor(TestAdaptor):
 
         adaptor = ConferenceAdaptor(dao)
 
-        assert_that(adaptor.generate(CONTEXT), contains(('4000', 'confbridge:1')))
+        assert_that(adaptor.generate(CONTEXT), contains_exactly(('4000', 'confbridge:1')))
         dao.conference_hints.assert_called_once_with(CONTEXT)
 
 
@@ -91,7 +91,7 @@ class TestForwardAdaptor(TestAdaptor):
                                                argument='1234')]
 
         assert_that(self.adaptor.generate(CONTEXT),
-                    contains(('*73542***223*1234', 'Custom:*73542***223*1234')))
+                    contains_exactly(('*73542***223*1234', 'Custom:*73542***223*1234')))
         self.dao.forward_hints.assert_called_once_with(CONTEXT)
 
     def test_given_hint_without_argument_then_generates_progfunckey_without_argument(self):
@@ -100,7 +100,7 @@ class TestForwardAdaptor(TestAdaptor):
                                                argument=None)]
 
         assert_that(self.adaptor.generate(CONTEXT),
-                    contains(('*73542***223', 'Custom:*73542***223')))
+                    contains_exactly(('*73542***223', 'Custom:*73542***223')))
 
 
 class TestServiceAdaptor(TestAdaptor):
@@ -115,7 +115,7 @@ class TestServiceAdaptor(TestAdaptor):
         adaptor = ServiceAdaptor(dao)
 
         assert_that(adaptor.generate(CONTEXT),
-                    contains(('*73542***226', 'Custom:*73542***226')))
+                    contains_exactly(('*73542***226', 'Custom:*73542***226')))
         dao.service_hints.assert_called_once_with(CONTEXT)
 
 
@@ -131,7 +131,7 @@ class TestAgentAdaptor(TestAdaptor):
         adaptor = AgentAdaptor(dao)
 
         assert_that(adaptor.generate(CONTEXT),
-                    contains(('*73542***231***356', 'Custom:*73542***231***356')))
+                    contains_exactly(('*73542***231***356', 'Custom:*73542***231***356')))
         dao.agent_hints.assert_called_once_with(CONTEXT)
 
 
@@ -146,7 +146,7 @@ class TestCustomAdaptor(TestAdaptor):
         adaptor = CustomAdaptor(dao)
 
         assert_that(adaptor.generate(CONTEXT),
-                    contains(('1234', 'Custom:1234')))
+                    contains_exactly(('1234', 'Custom:1234')))
         dao.custom_hints.assert_called_once_with(CONTEXT)
 
 
@@ -161,7 +161,7 @@ class TestBSFilterAdaptor(TestAdaptor):
         adaptor = BSFilterAdaptor(dao)
 
         assert_that(adaptor.generate(CONTEXT),
-                    contains(('*3712', 'Custom:*3712')))
+                    contains_exactly(('*3712', 'Custom:*3712')))
         dao.bsfilter_hints.assert_called_once_with(CONTEXT)
 
 
@@ -177,5 +177,5 @@ class TestGroupMemberAdaptor(TestAdaptor):
         adaptor = GroupMemberAdaptor(dao)
 
         assert_that(adaptor.generate(CONTEXT),
-                    contains(('*73542***250*18', 'Custom:*73542***250*18')))
+                    contains_exactly(('*73542***250*18', 'Custom:*73542***250*18')))
         dao.groupmember_hints.assert_called_once_with(CONTEXT)

--- a/wazo_confgend/hints/tests/test_generator.py
+++ b/wazo_confgend/hints/tests/test_generator.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 
 from mock import Mock, patch
-from hamcrest import assert_that, contains
+from hamcrest import assert_that, contains_exactly
 
 from ..import adaptor
 from ..generator import HintGenerator
@@ -22,7 +22,7 @@ class TestGenerator(unittest.TestCase):
 
         generator = HintGenerator([adaptor], [])
 
-        assert_that(generator.generate(CONTEXT), contains())
+        assert_that(generator.generate(CONTEXT), contains_exactly())
 
     def test_given_an_adaptor_generates_a_hint_then_generator_returns_formatted_hint(self):
         adaptor = Mock(HintAdaptor)
@@ -30,7 +30,7 @@ class TestGenerator(unittest.TestCase):
 
         generator = HintGenerator([adaptor], [])
 
-        assert_that(generator.generate(CONTEXT), contains('exten = 4000,hint,confbridge:1'))
+        assert_that(generator.generate(CONTEXT), contains_exactly('exten = 4000,hint,confbridge:1'))
         adaptor.generate.assert_called_once_with(CONTEXT)
 
     def test_given_2_adaptors_then_generates_hint_for_all_adaptors(self):
@@ -43,8 +43,8 @@ class TestGenerator(unittest.TestCase):
         generator = HintGenerator([first_adaptor, second_adaptor], [])
 
         assert_that(generator.generate(CONTEXT),
-                    contains('exten = 1000,hint,1000',
-                             'exten = 4000,hint,confbridge:1'))
+                    contains_exactly('exten = 1000,hint,1000',
+                                     'exten = 4000,hint,confbridge:1'))
         first_adaptor.generate.assert_called_once_with(CONTEXT)
         second_adaptor.generate.assert_called_once_with(CONTEXT)
 
@@ -57,7 +57,7 @@ class TestGenerator(unittest.TestCase):
 
         generator = HintGenerator([first_adaptor, second_adaptor], [])
 
-        assert_that(generator.generate(CONTEXT), contains('exten = 1000,hint,PJSIP/abcdef'))
+        assert_that(generator.generate(CONTEXT), contains_exactly('exten = 1000,hint,PJSIP/abcdef'))
         first_adaptor.generate.assert_called_once_with(CONTEXT)
         second_adaptor.generate.assert_called_once_with(CONTEXT)
 
@@ -67,7 +67,7 @@ class TestGenerator(unittest.TestCase):
 
         generator = HintGenerator([], [first_adaptor])
 
-        assert_that(generator.generate_global_hints(), contains(
+        assert_that(generator.generate_global_hints(), contains_exactly(
             'exten = 1001,hint,PJSIP/abc&SCCP/1042',
         ))
 
@@ -86,5 +86,5 @@ class TestGenerator(unittest.TestCase):
             result = generator.generate(CONTEXT)
             assert_that(
                 list(result),
-                contains('exten = 1000,hint,PJSIP/abcdef'),
+                contains_exactly('exten = 1000,hint,PJSIP/abcdef'),
             )

--- a/wazo_confgend/plugins/confbridge_conf.py
+++ b/wazo_confgend/plugins/confbridge_conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
@@ -40,6 +40,9 @@ class _ConfBridgeConf(object):
         print >> output
 
         self._gen_default_menu(output)
+        print >> output
+
+        self._gen_meeting_config(output)
         print >> output
 
     def _gen_bridge_profile(self, conferences, output):
@@ -125,3 +128,32 @@ class _ConfBridgeConf(object):
         yield '2 = admin_toggle_conference_lock'
         yield '3 = admin_kick_last'
         yield '0 = admin_toggle_mute_participants'
+
+    def _gen_meeting_config(self, output):
+        for line in self._gen_default_meeting_config():
+            print >> output, line
+
+    def _gen_default_meeting_config(self):
+        yield '[wazo-meeting-bridge-profile]'
+        yield 'type = bridge'
+        yield 'video_mode = sfu'
+        yield 'remb_send_interval = 1000'
+        yield 'remb_behavior = lowest_all'
+        yield 'max_members = 50'
+        yield 'record_conference = no'
+        yield 'enable_events = yes'
+        yield ''
+        yield '[wazo-meeting-user-profile]'
+        yield 'dsp_drop_silence = yes'
+        yield 'type = user'
+        yield 'talk_detection_events = yes'
+        yield 'echo_events = yes'
+        yield 'send_events = yes'
+        yield 'announce_join_leave = no'
+        yield 'announce_user_count = no'
+        yield 'announce_only_user = no'
+        yield ''
+        yield '[wazo-meeting-menu]'
+        yield 'type = menu'
+        yield '* = playback_and_continue(dir-multi1&digits/1&confbridge-mute-out)'
+        yield '1 = toggle_mute'

--- a/wazo_confgend/plugins/tests/test_pjsip_conf.py
+++ b/wazo_confgend/plugins/tests/test_pjsip_conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -104,6 +104,95 @@ class TestPJSIPConfGenerator(unittest.TestCase):
             ]
 
             self.generator.generate_lines(output)
+            result = output.getvalue()
+            assert_config_equal(
+                result,
+                '''\
+                ; {label_1}
+                [{name_1}]
+                type = endpoint
+                aors = {name_1}
+                auth = {name_1}
+                allow = !all,ulaw
+
+                [{name_1}]
+                type = aor
+                qualify_frequency = 60
+
+                [{name_1}]
+                type = auth
+                username = iddqd
+
+                ; {label_2}
+                [{name_2}]
+                type = endpoint
+                aors = {name_2}
+                auth = {name_2}
+                allow = !all,ulaw,g729
+
+                [{name_2}]
+                type = aor
+                qualify_frequency = 42
+
+                [{name_2}]
+                type = auth
+                username = idbehold
+                '''.format(
+                    label_1=label_1,
+                    label_2=label_2,
+                    name_1=name_1,
+                    name_2=name_2,
+                )
+            )
+
+    def test_generate_meeting_guests(self):
+        output = StringIO()
+        name_1 = 'abcdef'
+        label_1 = 'meeting_guest_1_uuid'
+        name_2 = 'ghijkl'
+        label_2 = 'meeting_guest_2_uuid'
+
+        with patch('wazo_confgend.plugins.pjsip_conf.asterisk_conf_dao') as dao:
+            dao.find_sip_meeting_guests_settings.return_value = [
+                {
+                    'name': name_1,
+                    'label': label_1,
+                    'aor_section_options': [
+                        ['type', 'aor'],
+                        ['qualify_frequency', '60'],
+                    ],
+                    'auth_section_options': [
+                        ['type', 'auth'],
+                        ['username', 'iddqd'],
+                    ],
+                    'endpoint_section_options': [
+                        ['type', 'endpoint'],
+                        ['aors', name_1],
+                        ['auth', name_1],
+                        ['allow', '!all,ulaw'],
+                    ],
+                },
+                {
+                    'name': name_2,
+                    'label': label_2,
+                    'aor_section_options': [
+                        ['type', 'aor'],
+                        ['qualify_frequency', '42'],
+                    ],
+                    'auth_section_options': [
+                        ['type', 'auth'],
+                        ['username', 'idbehold'],
+                    ],
+                    'endpoint_section_options': [
+                        ['type', 'endpoint'],
+                        ['aors', name_2],
+                        ['auth', name_2],
+                        ['allow', '!all,ulaw,g729'],
+                    ],
+                },
+            ]
+
+            self.generator.generate_meeting_guests(output)
             result = output.getvalue()
             assert_config_equal(
                 result,

--- a/wazo_confgend/templates/asterisk/extensions/meeting-guest.jinja
+++ b/wazo_confgend/templates/asterisk/extensions/meeting-guest.jinja
@@ -1,0 +1,8 @@
+{% for meeting in meetings -%}
+[wazo-meeting-{{ meeting.uuid }}-guest]
+exten = meeting-guest,1,NoOp(New guest participant in the meeting)
+same = n,Set(WAZO_TENANT_UUID={{ meeting.tenant_uuid }})
+same = n,Set(WAZO_MEETING_UUID={{ meeting.uuid }})
+same = n,Goto(wazo-meeting,participant,1)
+
+{% endfor %}

--- a/wazo_confgend/templates/asterisk/extensions/meeting-guest.jinja
+++ b/wazo_confgend/templates/asterisk/extensions/meeting-guest.jinja
@@ -1,8 +1,6 @@
 {% for meeting in meetings -%}
 [wazo-meeting-{{ meeting.uuid }}-guest]
 exten = meeting-guest,1,NoOp(New guest participant in the meeting)
-same = n,Set(WAZO_TENANT_UUID={{ meeting.tenant_uuid }})
-same = n,Set(WAZO_MEETING_UUID={{ meeting.uuid }})
 same = n,Goto(wazo-meeting,participant,1)
 
 {% endfor %}

--- a/wazo_confgend/templates/asterisk/extensions/meeting-user.jinja
+++ b/wazo_confgend/templates/asterisk/extensions/meeting-user.jinja
@@ -1,0 +1,7 @@
+{% for meeting in meetings -%}
+exten = wazo-meeting-{{ meeting.uuid }},1,NoOp(New user participant in meeting)
+same = n,Set(WAZO_TENANT_UUID={{ meeting.tenant_uuid }})
+same = n,Set(WAZO_MEETING_UUID={{ meeting.uuid }})
+same = n,Goto(wazo-meeting,participant,1)
+
+{% endfor %}

--- a/wazo_confgend/tests/test_template.py
+++ b/wazo_confgend/tests/test_template.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
+import textwrap
 
 from os.path import basename
 from unittest import TestCase
 
 from jinja2 import PackageLoader, Template
 from hamcrest import assert_that, contains_string, equal_to
+from mock import Mock
 
 from ..template import TemplateHelper
 
@@ -120,3 +122,37 @@ class TestIVRTemplate(TestCase):
             output,
             contains_string(r'Gosub(forward,s,1(queue,1,5.0\;2\;'),
         )
+
+
+class TestMeetingUserTemplate(TestCase):
+
+    def setUp(self):
+        cwd = os.path.dirname(os.path.abspath(__file__))
+        self.template_path = os.path.abspath(
+            os.path.join(
+                cwd, '..', 'templates', 'asterisk', 'extensions', 'meeting-user.jinja',
+            ),
+        )
+        with open(self.template_path) as f:
+            self.template = Template(f.read())
+
+    def test_meeting_user_template(self):
+        meetings = [
+            Mock(tenant_uuid='tenant-uuid', uuid='uuid1'),
+            Mock(tenant_uuid='tenant-uuid', uuid='uuid2'),
+        ]
+
+        output = self.template.render(meetings=meetings)
+
+        assert output == textwrap.dedent('''\
+            exten = wazo-meeting-uuid1,1,NoOp(New user participant in meeting)
+            same = n,Set(WAZO_TENANT_UUID=tenant-uuid)
+            same = n,Set(WAZO_MEETING_UUID=uuid1)
+            same = n,Goto(wazo-meeting,participant,1)
+
+            exten = wazo-meeting-uuid2,1,NoOp(New user participant in meeting)
+            same = n,Set(WAZO_TENANT_UUID=tenant-uuid)
+            same = n,Set(WAZO_MEETING_UUID=uuid2)
+            same = n,Goto(wazo-meeting,participant,1)
+
+        ''')

--- a/wazo_confgend/tests/test_template.py
+++ b/wazo_confgend/tests/test_template.py
@@ -195,14 +195,10 @@ class TestMeetingGuestTemplate(TestCase):
         assert output == textwrap.dedent('''\
             [wazo-meeting-uuid1-guest]
             exten = meeting-guest,1,NoOp(New guest participant in the meeting)
-            same = n,Set(WAZO_TENANT_UUID=tenant-uuid)
-            same = n,Set(WAZO_MEETING_UUID=uuid1)
             same = n,Goto(wazo-meeting,participant,1)
 
             [wazo-meeting-uuid2-guest]
             exten = meeting-guest,1,NoOp(New guest participant in the meeting)
-            same = n,Set(WAZO_TENANT_UUID=tenant-uuid)
-            same = n,Set(WAZO_MEETING_UUID=uuid2)
             same = n,Goto(wazo-meeting,participant,1)
 
         ''')

--- a/wazo_confgend/tests/test_template.py
+++ b/wazo_confgend/tests/test_template.py
@@ -156,3 +156,39 @@ class TestMeetingUserTemplate(TestCase):
             same = n,Goto(wazo-meeting,participant,1)
 
         ''')
+
+
+class TestMeetingGuestTemplate(TestCase):
+
+    def setUp(self):
+        cwd = os.path.dirname(os.path.abspath(__file__))
+        self.template_path = os.path.abspath(
+            os.path.join(
+                cwd, '..', 'templates', 'asterisk', 'extensions', 'meeting-guest.jinja',
+            ),
+        )
+        with open(self.template_path) as f:
+            self.template = Template(f.read())
+
+    def test_meeting_guest_template(self):
+        meetings = [
+            Mock(tenant_uuid='tenant-uuid', uuid='uuid1'),
+            Mock(tenant_uuid='tenant-uuid', uuid='uuid2'),
+        ]
+
+        output = self.template.render(meetings=meetings)
+
+        assert output == textwrap.dedent('''\
+            [wazo-meeting-uuid1-guest]
+            exten = meeting-guest,1,NoOp(New guest participant in the meeting)
+            same = n,Set(WAZO_TENANT_UUID=tenant-uuid)
+            same = n,Set(WAZO_MEETING_UUID=uuid1)
+            same = n,Goto(wazo-meeting,participant,1)
+
+            [wazo-meeting-uuid2-guest]
+            exten = meeting-guest,1,NoOp(New guest participant in the meeting)
+            same = n,Set(WAZO_TENANT_UUID=tenant-uuid)
+            same = n,Set(WAZO_MEETING_UUID=uuid2)
+            same = n,Goto(wazo-meeting,participant,1)
+
+        ''')

--- a/wazo_confgend/tests/test_template.py
+++ b/wazo_confgend/tests/test_template.py
@@ -136,6 +136,13 @@ class TestMeetingUserTemplate(TestCase):
         with open(self.template_path) as f:
             self.template = Template(f.read())
 
+    def test_empty(self):
+        meetings = []
+
+        output = self.template.render(meetings=meetings)
+
+        assert output == ''
+
     def test_meeting_user_template(self):
         meetings = [
             Mock(tenant_uuid='tenant-uuid', uuid='uuid1'),
@@ -169,6 +176,13 @@ class TestMeetingGuestTemplate(TestCase):
         )
         with open(self.template_path) as f:
             self.template = Template(f.read())
+
+    def test_empty(self):
+        meetings = []
+
+        output = self.template.render(meetings=meetings)
+
+        assert output == ''
 
     def test_meeting_guest_template(self):
         meetings = [


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-dao/pull/137

## extensions.conf: add meetings for users


## tests: fix warnings from hamcrest

Why:

* contains() is deprecated in favor of contains_exactly()

## extensions.conf: add meetings for guests


## fixup! extensions.conf: add meetings for users


## meetings: test empty list of meetings