### PR TITLE
disable pjsip_phoneprov_provider module

### DIFF
--- a/etc/wazo-confgend/config.yml
+++ b/etc/wazo-confgend/config.yml
@@ -90,6 +90,7 @@ enabled_asterisk_modules:
   res_mwi_external.so: false
   res_phoneprov.so: false
   res_pjsip_config_wizard.so: false
+  res_pjsip_phoneprov_provider.so: false
   res_snmp.so: false
   res_stasis_mailbox.so: false
   res_statsd.so: false


### PR DESCRIPTION
why: it depends from res_phoneprov module which is already disabled
Adding explicit disable will remove error log at asterisk boot