### PR TITLE
[WAZO-2772] provd network: extract more values from the database

### DIFF
--- a/wazo_confgend/plugins/provd_conf.py
+++ b/wazo_confgend/plugins/provd_conf.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import unicode_literals
 
-import textwrap
+import yaml
 
 from xivo_dao import init_db_from_config
 from xivo_dao.helpers.db_utils import session_scope
@@ -29,14 +29,30 @@ class ProvdNetworkConfGenerator(object):
             return
         return result.address
 
+    def get_provd_http_port(self, session):
+        result = session.query(Provisioning.http_port).first()
+        if not result:
+            return
+        return result.http_port
+
     def generate(self):
         with session_scope(read_only=True) as session:
-            address = self.get_provd_net4_ip(session) or self.get_netiface_net4_ip(session)
+            config = {}
+            external_ip = self.get_provd_net4_ip(session) or self.get_netiface_net4_ip(session)
+            external_port = self.get_provd_http_port(session)
 
-        if not address:
-            return ''
+            sections = {
+                'general': {
+                    'external_ip': external_ip,
+                    'http_port': external_port,
+                }
+            }
 
-        return textwrap.dedent('''\
-            general:
-                external_ip: {}
-        '''.format(address))
+            for section_name, section_value in sections.iteritems():
+                for option, value in section_value.iteritems():
+                    if value:
+                        if section_name not in config:
+                            config.update({section_name: {}})
+                        config[section_name][option] = value
+
+        return yaml.safe_dump(config, default_flow_style=False)

--- a/wazo_confgend/plugins/tests/test_provd_conf.py
+++ b/wazo_confgend/plugins/tests/test_provd_conf.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
 import textwrap
 
 from mock import Mock, patch
-
 from wazo_confgend.generators.tests.util import assert_config_equal
 
 from ..provd_conf import ProvdNetworkConfGenerator
@@ -23,8 +22,12 @@ class TestProvdNetworkConf(unittest.TestCase):
         session_scope.__enter__ = Mock(return_value=Mock())
         session_scope.__exit__ = Mock(return_value=None)
 
-        with patch.object(self.generator, 'get_provd_net4_ip') as net4_ip:
-            net4_ip.return_value = '10.0.0.254'
+        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip,\
+                patch.object(self.generator, 'get_provd_http_port') as provd_http_port,\
+                patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip:
+            provd_net4_ip.return_value = '10.0.0.254'
+            provd_http_port.return_value = None
+            netiface_net4_ip.return_value = None
 
             value = self.generator.generate()
 
@@ -38,13 +41,14 @@ class TestProvdNetworkConf(unittest.TestCase):
         session_scope.__enter__ = Mock(return_value=Mock())
         session_scope.__exit__ = Mock(return_value=None)
 
-        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip:
+        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip,\
+                patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip,\
+                patch.object(self.generator, 'get_provd_http_port') as provd_http_port:
             provd_net4_ip.return_value = None
+            provd_http_port.return_value = None
+            netiface_net4_ip.return_value = '10.0.0.250'
 
-            with patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip:
-                netiface_net4_ip.return_value = '10.0.0.250'
-
-                value = self.generator.generate()
+            value = self.generator.generate()
 
         assert_config_equal(value, textwrap.dedent('''\
             general:
@@ -52,16 +56,37 @@ class TestProvdNetworkConf(unittest.TestCase):
         '''))
 
     @patch('wazo_confgend.plugins.provd_conf.session_scope')
-    def test_no_net4_ip(self, session_scope):
+    def test_complete_configuration(self, session_scope):
         session_scope.__enter__ = Mock(return_value=Mock())
         session_scope.__exit__ = Mock(return_value=None)
 
-        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip:
+        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip,\
+                patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip,\
+                patch.object(self.generator, 'get_provd_http_port') as provd_http_port:
+            provd_net4_ip.return_value = '10.0.0.254'
+            provd_http_port.return_value = 8666
+            netiface_net4_ip.return_value = '10.0.0.222'
+
+            value = self.generator.generate()
+
+        assert_config_equal(value, textwrap.dedent('''\
+            general:
+                external_ip: 10.0.0.254
+                http_port: 8666
+        '''))
+
+    @patch('wazo_confgend.plugins.provd_conf.session_scope')
+    def test_no_external_ip(self, session_scope):
+        session_scope.__enter__ = Mock(return_value=Mock())
+        session_scope.__exit__ = Mock(return_value=None)
+
+        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip,\
+                patch.object(self.generator, 'get_provd_http_port') as provd_http_port,\
+                patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip:
             provd_net4_ip.return_value = None
+            provd_http_port.return_value = None
+            netiface_net4_ip.return_value = None
 
-            with patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip:
-                netiface_net4_ip.return_value = None
+            value = self.generator.generate()
 
-                value = self.generator.generate()
-
-        assert_config_equal(value, '')
+        assert_config_equal(value, '{}')


### PR DESCRIPTION
I am reviving this OLD branch that was forgotten. Without this, the provisioning port section in the provd API (and in confd) is useless since the configuration file is not generated.