### PR TITLE
docker: fix building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ RUN apt-get install -y gcc
 
 COPY requirements.txt /usr/local/src/wazo-confgend/requirements.txt
 WORKDIR /usr/local/src/wazo-confgend
-RUN pip install -r requirements.txt
+# incremental is needed by twisted setup
+RUN pip install incremental==16.10.1 && \
+    pip install -r requirements.txt
 
 COPY setup.py /usr/local/src/wazo-confgend/
 COPY bin /usr/local/src/wazo-confgend/bin

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 https://github.com/wazo-platform/xivo-dao/archive/master.zip
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
+incremental==16.10.1  # from twisted
 jinja2==2.10
 psycopg2-binary
 pyyaml==3.13

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,10 @@ skipsdist = true
 [testenv]
 commands =
     pytest --junitxml=unit-tests.xml --cov=wazo_confgend --cov-report term --cov-report xml:coverage.xml wazo_confgend
+install_command =
+    bash -c "python -m pip install incremental==16.10.1 && python -m pip install $@" -- {opts} {packages}
+allowlist_externals =
+    bash
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
@@ -21,7 +25,8 @@ commands =
     -sh -c 'pycodestyle --ignore=E501 wazo_confgend > pycodestyle.txt'
 deps =
     pycodestyle
-whitelist_externals =
+allowlist_externals =
+    bash
     sh
 
 [testenv:pylint]
@@ -31,7 +36,8 @@ deps =
     -rrequirements.txt
     -rtest-requirements.txt
     pylint
-whitelist_externals =
+allowlist_externals =
+    bash
     sh
 
 [testenv:linters]


### PR DESCRIPTION
How:

* Twisted seems to download the latest version of the lib "incremental"
by itself, without regards for the constraints in requirements.txt.
* When installing typing from requirements.txt, Twisted loads
"incremental" before typing is even installed by pip