### PR TITLE
WAZO-2904: Refactored features.conf support into plugin

### DIFF
--- a/etc/wazo-confgend/config.yml
+++ b/etc/wazo-confgend/config.yml
@@ -106,3 +106,4 @@ plugins:
   asterisk.sip.conf: wazo
   asterisk.pjsip.conf: wazo
   provd.network.yml: wazo
+  asterisk.features.conf: wazo

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,8 @@ setup(
         'wazo_confgend.provd.network.yml': [
             'wazo = wazo_confgend.plugins.provd_conf:ProvdNetworkConfGenerator',
         ],
+        'wazo_confgend.asterisk.features.conf': [
+            'wazo = wazo_confgend.plugins.features_conf:FeaturesConfGenerator',
+        ],
     },
 )

--- a/wazo_confgend/handler.py
+++ b/wazo_confgend/handler.py
@@ -57,15 +57,17 @@ class PluginHandlerFactory(HandlerFactory):
             raise NoSuchHandler()
 
         try:
-            return driver.DriverManager(
+            generator = driver.DriverManager(
                 namespace=namespace,
                 name=driver_name,
                 invoke_on_load=True,
                 invoke_args=(self._dependencies,),
-            ).driver.generate
+            ).driver
         except RuntimeError:
             raise NoSuchHandler()
-
+        else:
+            logger.info("Loaded plugin %s for namespace %s", driver_name, namespace)
+            return generator.generate
 
 class FrontendHandlerFactory(HandlerFactory):
     def __init__(self, frontends):

--- a/wazo_confgend/plugins/features_conf.py
+++ b/wazo_confgend/plugins/features_conf.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 from wazo_confgend.generators.util import AsteriskFileWriter
-from wazo_confgend.generators.features import FeaturesConf
 from xivo_dao import asterisk_conf_dao
 import logging
 import io

--- a/wazo_confgend/plugins/features_conf.py
+++ b/wazo_confgend/plugins/features_conf.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import unicode_literals
+
+from wazo_confgend.generators.util import AsteriskFileWriter
+from wazo_confgend.generators.features import FeaturesConf
+from xivo_dao import asterisk_conf_dao
+import logging
+import io
+
+
+# A plugin supplies a generate method
+# TODO: define Protocol for generator plugin interface
+# class Generator(Protocol):
+#     def generate(self) -> str: pass
+
+class FeaturesConfGenerator:
+    # TODO: add type annots after python 3 mig
+    def __init__(self, dependencies):
+        self._settings = asterisk_conf_dao.find_features_settings()
+        self.logger = logging.getLogger(__name__).getChild(self.__class__.__name__)
+
+    def _generate_general(self, ast_file):
+        ast_file.write_section('general')
+        ast_file.write_options(self._settings['general_options'])
+
+    def _generate_featuremap(self, ast_file):
+        ast_file.write_section('featuremap')
+        ast_file.write_options(self._settings['featuremap_options'])
+
+    def _generate_applicationmap(self, ast_file):
+        ast_file.write_section('applicationmap')
+        ast_file.write_options(self._settings['applicationmap_options'])
+
+    def generate(self):
+        self.logger.debug("Generating config for features.conf")
+        output = io.StringIO()
+        ast_file = AsteriskFileWriter(output)
+        self._generate_general(ast_file)
+        self.logger.debug("Generated general section for features.conf")
+        self._generate_featuremap(ast_file)
+        self.logger.debug("Generated featuremap section for features.conf")
+        self._generate_applicationmap(ast_file)
+        self.logger.debug("Generated applicationmap section for features.conf")
+        return output.getvalue()


### PR DESCRIPTION
As a first contribution and in an effort to simplify modular handling of configurations, the support for asterisk/features.conf has been converted to the plugin interface.

As a continuation in this direction, all remaining configuration generators implemented through/behind "frontend" abstractions(`asterisk.AsteriskFrontend`, `wazo.WazoFrontend`, `phoned.PhonedFrontend`) should be converted to the plugin-based architecture. 
That is, all supported configurations can be declared as an entrypoint in the setup.py, and all implementations of configuration generators can follow the same interface: a class with a `generate` method taking no argument and returning a string containing the complete configuration. 
This should then enable use to remove the "frontend" layer and the `wazo_confgend.generators.*` non-utility modules in order to simplify the codebase.

Included commits were tested manually on an aws test environment wazo stack. 
After verifying through logs that the plugin was properly loaded and called from an invocation of `wazo-confgen asterisk/features.conf`, `diff` was invoked with the new output and a previously generated `features.conf`from the current production version, which verified the equivalence(no difference). 