### PR TITLE
pin automat dependency to support python2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 https://github.com/wazo-platform/xivo-dao/archive/master.zip
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
+automat==0.6.0  # from twisted
 incremental==16.10.1  # from twisted
 jinja2==2.10
 psycopg2-binary


### PR DESCRIPTION
why: twisted require unpinned automat version and this library has
released a new version (22.10.0) which is incompatible with python2

That's why we pin automat to buster version