### PR TITLE
debian: remove unused maintscript

### DIFF
--- a/debian/wazo-confgend.maintscript
+++ b/debian/wazo-confgend.maintscript
@@ -1,6 +1,0 @@
-# see: dh_installdeb(1)
-
-mv_conffile /etc/pf-xivo/xivo-confgend/asterisk/contexts.conf /etc/xivo/xivo-confgend/asterisk/contexts.conf 1:14.02
-mv_conffile /etc/pf-xivo/xivo-confgend.conf /etc/xivo/xivo-confgend.conf 1:14.02
-rm_conffile /etc/xivo/xivo-confgend.conf 1:16.09
-mv_conffile /etc/xivo/xivo-confgend/asterisk/contexts.conf /etc/xivo-confgend/templates/contexts.conf 1:16.09


### PR DESCRIPTION
why: package has been renamed