### PR TITLE
Wazo 2713 convert wazo confgend to python 3

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 .git
 .tox
 debian
+.venv

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ coverage.xml
 pycodestyle.txt
 pylint.txt
 unit-tests.xml
-# editor configurations
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage.xml
 pycodestyle.txt
 pylint.txt
 unit-tests.xml
+# editor configurations
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY requirements.txt /usr/local/src/wazo-confgend/requirements.txt
 WORKDIR /usr/local/src/wazo-confgend
-# incremental is needed by twisted setup
+
 RUN pip install -r requirements.txt
 
 COPY setup.py /usr/local/src/wazo-confgend/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,22 @@
-FROM python:2.7-slim-buster AS compile-image
+FROM python:3.7-slim-buster AS compile-image
 LABEL maintainer="Wazo Maintainers <dev@wazo.community>"
 
-RUN apt-get -qq update && apt-get -qq -y install python-virtualenv
-RUN virtualenv /opt/venv
+RUN apt-get -qq update && apt-get -qq -y install gcc
+RUN python3 -m venv /opt/venv
 # Activate virtual env
 ENV PATH="/opt/venv/bin:$PATH"
-
-RUN apt-get install -y gcc
 
 COPY requirements.txt /usr/local/src/wazo-confgend/requirements.txt
 WORKDIR /usr/local/src/wazo-confgend
 # incremental is needed by twisted setup
-RUN pip install incremental==16.10.1 && \
-    pip install -r requirements.txt
+RUN pip install -r requirements.txt
 
 COPY setup.py /usr/local/src/wazo-confgend/
 COPY bin /usr/local/src/wazo-confgend/bin
 COPY wazo_confgend /usr/local/src/wazo-confgend/wazo_confgend
 RUN python setup.py install
 
-FROM python:2.7-slim-buster AS build-image
+FROM python:3.7-slim-buster AS build-image
 COPY --from=compile-image /opt/venv /opt/venv
 
 COPY ./etc/wazo-confgend /etc/wazo-confgend

--- a/bin/wazo-confgend
+++ b/bin/wazo-confgend
@@ -1,6 +1,6 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2016 Avencall
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_confgend.bin.daemon import main, twisted_application

--- a/bin/wazo-confgend
+++ b/bin/wazo-confgend
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/debian/control
+++ b/debian/control
@@ -1,36 +1,34 @@
 Source: wazo-confgend
-Section: python
+Section: python3
 Priority: optional
 Maintainer: Wazo Maintainers <dev@wazo.community>
-Build-Depends: debhelper (>= 9), dh-python, dh-systemd (>= 1.5), python-all (>= 2.7), python-setuptools
+Build-Depends: debhelper (>= 9), dh-python, dh-systemd (>= 1.5), python3-all (>= 3.7), python3-setuptools
 Standards-Version: 3.9.6
-X-Python-Version: >= 2.7
+X-Python3-Version: >= 3.7
 
 Package: wazo-confgend
 Architecture: all
 Depends:
-  ${python:Depends},
+  ${python3:Depends},
   ${misc:Depends},
   adduser,
-  python-jinja2,
-  python-stevedore,
-  python-twisted,
-  python-yaml,
+  python3-jinja2,
+  python3-stevedore,
+  python3-twisted,
+  python3-yaml,
   rename,
-  xivo-lib-python,
-  xivo-libdao
+  xivo-lib-python-python3,
+  xivo-libdao-python3
 Provides: xivo-confgend, xivo-libconfgend
 Replaces: xivo-confgend, xivo-libconfgend
 Conflicts: xivo-confgend, xivo-libconfgend
 Suggests: wazo-confgen
 Description: Wazo telephony systems configurations generator
- Wazo is a system based on a powerful IPBX, to bring an easy to
- install solution for telephony and related services.
+ Wazo is a system based on a powerful IPBX, aiming to provide an easy-to-install solution for telephony and related services.
  .
- Confgen generate asterisk/freeswitch or any other telephony system 
- configuration from a Wazo configuration.
- Confgen is build on a flexible architecture of frontends (targeted systems) 
+ Confgen generates configurations for asterisk/freeswitch and other telephony systems from Wazo configuration sources.
+ Confgen is built on a flexible architecture of frontends (targeted systems)
  and backends (data source).
  .
- confgend is the server part of the generator
+ confgend is the server component of the generator.
  .

--- a/debian/rules
+++ b/debian/rules
@@ -1,8 +1,11 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+export PYBUILD_NAME=wazo-confgend
+export PYBUILD_DISABLE=test
+
 %:
-	dh $@ --with python2,systemd
+	dh $@ --with python3,systemd --buildsystem=pybuild
 
 override_dh_installinit:
 	dh_installinit --noscripts

--- a/debian/wazo-confgend.service
+++ b/debian/wazo-confgend.service
@@ -6,7 +6,7 @@ Before=monit.service
 [Service]
 Type=forking
 ExecStartPre=/usr/bin/install -d -o wazo-confgend -g wazo-confgend /run/wazo-confgend
-ExecStart=/usr/bin/twistd --pidfile=/run/wazo-confgend/wazo-confgend.pid --rundir=/ --uid=wazo-confgend --gid=wazo-confgend --python=/usr/bin/wazo-confgend --no_save --logger wazo_confgend.bin.daemon.twistd_logs
+ExecStart=/usr/bin/twistd3 --pidfile=/run/wazo-confgend/wazo-confgend.pid --rundir=/ --uid=wazo-confgend --gid=wazo-confgend --python=/usr/bin/wazo-confgend --no_save --logger wazo_confgend.bin.daemon.twistd_logs
 PIDFile=/run/wazo-confgend/wazo-confgend.pid
 SyslogIdentifier=wazo-confgend
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 https://github.com/wazo-platform/xivo-dao/archive/master.zip
 https://github.com/wazo-platform/xivo-lib-python/archive/master.zip
 automat==0.6.0  # from twisted
-incremental==16.10.1  # from twisted
 jinja2==2.10
+markupsafe==2.0.1 # via jinja2, see https://github.com/pallets/jinja/issues/1585
 psycopg2-binary
 pyyaml==3.13
 sqlalchemy==1.2.18

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from setuptools import setup

--- a/tests/flatten_asterisk_conf.py
+++ b/tests/flatten_asterisk_conf.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+# simple utility script to transform an asterisk/ini-like conf file
+# into a linear stream of namespaced option definitions, i.e. {section}.{option}={value}
+# while conserving the original ordering of sections and options, allowing for easier semantic comparison
+
+from typing import TextIO
+from wazo_confgend.helpers.asterisk import asterisk_parser
+import sys
+
+
+def simplify_config_stream(file: TextIO):
+    config = asterisk_parser(file)
+    for section in config.sections():
+        print("section:", section, file=sys.stderr)
+        for (opt, val) in config.items(section):
+            print("option:", opt, val, file=sys.stderr)
+            yield (f"{section}.{opt}={val}")
+
+
+if __name__ == "__main__":
+    config_file = open(sys.argv[1]) if len(sys.argv) >= 2 else sys.stdin
+    with config_file:
+        print(config_file, file=sys.stderr)
+        for abs_opt in simplify_config_stream(config_file):
+            print(abs_opt)
+
+        exit(0)

--- a/tests/test_diff.sh
+++ b/tests/test_diff.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+## helper script for manual testing of confgend output
+## given two directories as arguments, will compare corresponding files
+## using text diff and a more semantic diff
+
+set -euo pipefail
+
+
+function mkworkdir(){
+    mkdir -p $PWD/.diff-tests
+    mktemp -p .diff-tests -d
+}
+
+function list_pairs(){
+    olddir=$(realpath -e --relative-base $PWD $1)
+    newdir=$(realpath -e --relative-base $PWD $2)
+    find $olddir -type f -exec basename {} \; | while read file; do
+        echo $(realpath -e $olddir/$file) $(realpath -e $newdir/$file)
+    done
+}
+
+diff="git diff --no-index"
+flatten_asterisk_conf="python3 $(dirname $0)/flatten_asterisk_conf.py"
+
+function generate_diff(){
+    workdir=${WORKDIR:-$(mkworkdir)}
+    #reportfile=$workdir/report.txt
+    #touch $reportfile
+    while read oldfile newfile; do
+        echo "$oldfile" "$newfile" 1>&2
+
+        difffile=$workdir/$(basename $oldfile).diff
+        $diff $oldfile $newfile > $difffile || true
+        # mention diff if not empty
+        if test -s $difffile; then
+            echo diff $oldfile $newfile $difffile
+        fi
+
+        # a utility script is used to flatten config files,
+        # by prepending sections to option names,
+        # so that line sorting doesn't destroy semantics of configs,
+        oldflattened=$workdir/$(echo $oldfile | tr '/' '-').flat
+        $flatten_asterisk_conf $oldfile > $oldflattened
+        newflattened=$workdir/$(echo $newfile | tr '/' '-').flat
+        $flatten_asterisk_conf $oldfile > $newflattened
+
+        # compute sorted diff to check if the same options are present regardless of ordering
+        oldsorted=$workdir/$(echo $oldfile | tr '/' '-').flat.sorted
+        sort $oldflattened > $oldsorted;
+        newsorted=$workdir/$(echo $newfile | tr '/' '-').flat.sorted
+        sort $newflattened > $newsorted;
+
+        sorted_difffile=$workdir/$(basename $oldfile).flat.sorted.diff
+        $diff $oldsorted $newsorted > $sorted_difffile || true
+
+        if test -s $sorted_difffile; then
+            echo sorteddiff $oldfile $newfile $sorted_difffile
+        fi
+    done
+}
+
+list_pairs $@ | generate_diff

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,6 @@ install_command =
     bash -c "python -m pip install incremental==16.10.1 && python -m pip install $@" -- {opts} {packages}
 allowlist_externals =
     bash
-whitelist_externals =
-    bash
 
 deps =
     -rrequirements.txt
@@ -32,9 +30,6 @@ deps =
 allowlist_externals =
     bash
     sh
-whitelist_externals =
-    bash
-    sh
 
 [testenv:pylint]
 commands =
@@ -44,9 +39,6 @@ deps =
     -rtest-requirements.txt
     pylint
 allowlist_externals =
-    bash
-    sh
-whitelist_externals =
     bash
     sh
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, pycodestyle, pylint
+envlist = py37, pycodestyle, pylint, linters
 skipsdist = true
 
 [testenv]
 commands =
     pytest --junitxml=unit-tests.xml --cov=wazo_confgend --cov-report term --cov-report xml:coverage.xml {posargs:} wazo_confgend
-# this can be removed while dropping python 2.7 support(confgend/python3 will work with incremental>16.10.1)
-allowlist_externals =
-    bash
 
 deps =
     -rrequirements.txt
@@ -30,14 +27,15 @@ allowlist_externals =
     sh
 
 [testenv:pylint]
+basepython = python3.7
+skip_install = true
 commands =
-    -sh -c 'pylint --rcfile=/usr/share/xivo-ci/pylintrc wazo_confgend > pylint.txt'
+    -sh -c 'pylint --rcfile={env:WAZO_CI_PYLINTRC:/usr/share/xivo-ci/pylintrc} wazo_confgend > pylint.txt'
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
     pylint
 allowlist_externals =
-    bash
     sh
 
 [testenv:linters]
@@ -47,12 +45,12 @@ deps =
     flake8
     flake8-colors
 commands =
-    flake8
+    flake8 {posargs:}
 
 [flake8]
 # E501: line too long (80 chars)
 # W503: line break before binary operator
-exclude = .tox,.eggs
+exclude = .tox,.eggs,.venv
 show-source = true
 ignore = E501, W503
 max-line-length = 99

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,8 @@ skipsdist = true
 
 [testenv]
 commands =
-    pytest --junitxml=unit-tests.xml --cov=wazo_confgend --cov-report term --cov-report xml:coverage.xml wazo_confgend
+    pytest --junitxml=unit-tests.xml --cov=wazo_confgend --cov-report term --cov-report xml:coverage.xml {posargs:} wazo_confgend
 # this can be removed while dropping python 2.7 support(confgend/python3 will work with incremental>16.10.1)
-install_command =
-    bash -c "python -m pip install incremental==16.10.1 && python -m pip install $@" -- {opts} {packages}
 allowlist_externals =
     bash
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,16 +4,20 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pycodestyle, pylint
+envlist = py37, pycodestyle, pylint
 skipsdist = true
 
 [testenv]
 commands =
     pytest --junitxml=unit-tests.xml --cov=wazo_confgend --cov-report term --cov-report xml:coverage.xml wazo_confgend
+# this can be removed while dropping python 2.7 support(confgend/python3 will work with incremental>16.10.1)
 install_command =
     bash -c "python -m pip install incremental==16.10.1 && python -m pip install $@" -- {opts} {packages}
 allowlist_externals =
     bash
+whitelist_externals =
+    bash
+
 deps =
     -rrequirements.txt
     -rtest-requirements.txt
@@ -28,6 +32,9 @@ deps =
 allowlist_externals =
     bash
     sh
+whitelist_externals =
+    bash
+    sh
 
 [testenv:pylint]
 commands =
@@ -39,9 +46,12 @@ deps =
 allowlist_externals =
     bash
     sh
+whitelist_externals =
+    bash
+    sh
 
 [testenv:linters]
-basepython = python2.7
+basepython = python3.7
 skip_install = true
 deps =
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -42,10 +42,17 @@ allowlist_externals =
 basepython = python3.7
 skip_install = true
 deps =
+    black
     flake8
     flake8-colors
 commands =
-    flake8 {posargs:}
+    black --skip-string-normalization --check {posargs:wazo_confgend}
+    flake8 {posargs:wazo_confgend}
+
+[testenv:black]
+skip_install = true
+deps = black
+commands = black --skip-string-normalization {posargs:wazo_confgend}
 
 [flake8]
 # E501: line too long (80 chars)

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = py37, pycodestyle, pylint, linters
 skipsdist = true
 
 [testenv]
+basepython = python3.7
 commands =
     pytest --junitxml=unit-tests.xml --cov=wazo_confgend --cov-report term --cov-report xml:coverage.xml {posargs:} wazo_confgend
 
@@ -27,7 +28,6 @@ allowlist_externals =
     sh
 
 [testenv:pylint]
-basepython = python3.7
 skip_install = true
 commands =
     -sh -c 'pylint --rcfile={env:WAZO_CI_PYLINTRC:/usr/share/xivo-ci/pylintrc} wazo_confgend > pylint.txt'
@@ -39,7 +39,6 @@ allowlist_externals =
     sh
 
 [testenv:linters]
-basepython = python3.7
 skip_install = true
 deps =
     black

--- a/wazo_confgend/__init__.py
+++ b/wazo_confgend/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013-2014 Avencall
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_confgend/asterisk.py
+++ b/wazo_confgend/asterisk.py
@@ -2,9 +2,9 @@
 # Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
 
-from StringIO import StringIO
+
+from io import StringIO
 
 from wazo_confgend.generators.extensionsconf import ExtensionsConf
 from wazo_confgend.generators.iax import IaxConf

--- a/wazo_confgend/asterisk.py
+++ b/wazo_confgend/asterisk.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 from io import StringIO
 
 from wazo_confgend.generators.extensionsconf import ExtensionsConf
@@ -18,7 +17,6 @@ from xivo_dao import asterisk_conf_dao
 
 
 class AsteriskFrontend(object):
-
     def __init__(self, config, tpl_helper):
         self.contextsconf = config['templates']['contextsconf']
         self._tpl_helper = tpl_helper
@@ -38,7 +36,9 @@ class AsteriskFrontend(object):
 
     def extensions_conf(self):
         hint_generator = HintGenerator.build()
-        config_generator = ExtensionsConf(self.contextsconf, hint_generator, self._tpl_helper)
+        config_generator = ExtensionsConf(
+            self.contextsconf, hint_generator, self._tpl_helper
+        )
         return self._generate_conf_from_generator(config_generator)
 
     def queues_conf(self):
@@ -96,11 +96,15 @@ class AsteriskFrontend(object):
 
             if m['maxp_sign'] is not None and m['maxp_value'] is not None:
                 sign = '' if m['maxp_sign'] == '=' else m['maxp_sign']
-                penalty_change = '{}{}{:d}'.format(penalty_change, sign, m['maxp_value'])
+                penalty_change = '{}{}{:d}'.format(
+                    penalty_change, sign, m['maxp_value']
+                )
 
             if m['minp_sign'] is not None and m['minp_value'] is not None:
                 sign = '' if m['minp_sign'] == '=' else m['minp_sign']
-                penalty_change = '{},{}{:d}'.format(penalty_change, sign, m['minp_value'])
+                penalty_change = '{},{}{:d}'.format(
+                    penalty_change, sign, m['minp_value']
+                )
 
             ast_writer.write_object_option('penaltychange', penalty_change)
             ast_writer.write_newline()

--- a/wazo_confgend/asterisk.py
+++ b/wazo_confgend/asterisk.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/asterisk.py
+++ b/wazo_confgend/asterisk.py
@@ -61,7 +61,7 @@ class AsteriskFrontend:
         agent_id = None
         for sk in asterisk_conf_dao.find_agent_queue_skills_settings():
             if agent_id != sk['id']:
-                ast_writer.write_section('agent-{:d}'.format(sk['id']))
+                ast_writer.write_section(f"agent-{sk['id']:d}")
                 agent_id = sk['id']
             ast_writer.write_option(sk['name'], sk['weight'])
 
@@ -73,7 +73,7 @@ class AsteriskFrontend:
         ast_writer = AsteriskFileWriter(output)
 
         for r in asterisk_conf_dao.find_queue_skillrule_settings():
-            ast_writer.write_section('skillrule-{}'.format(r['id']))
+            ast_writer.write_section(f"skillrule-{r['id']}")
             if 'rule' in r and r['rule'] is not None:
                 for rule in r['rule'].split(';'):
                     ast_writer.write_option('rule', rule)
@@ -91,19 +91,15 @@ class AsteriskFrontend:
                 ast_writer.write_newline()
                 ast_writer.write_section(rule)
 
-            penalty_change = '{:d}'.format(m['seconds'])
+            penalty_change = f"{m['seconds']:d}"
 
             if m['maxp_sign'] is not None and m['maxp_value'] is not None:
                 sign = '' if m['maxp_sign'] == '=' else m['maxp_sign']
-                penalty_change = '{}{}{:d}'.format(
-                    penalty_change, sign, m['maxp_value']
-                )
+                penalty_change = f"{penalty_change}{sign}{m['maxp_value']:d}"
 
             if m['minp_sign'] is not None and m['minp_value'] is not None:
                 sign = '' if m['minp_sign'] == '=' else m['minp_sign']
-                penalty_change = '{},{}{:d}'.format(
-                    penalty_change, sign, m['minp_value']
-                )
+                penalty_change = f"{penalty_change},{sign}{m['minp_value']:d}"
 
             ast_writer.write_object_option('penaltychange', penalty_change)
             ast_writer.write_newline()

--- a/wazo_confgend/asterisk.py
+++ b/wazo_confgend/asterisk.py
@@ -15,7 +15,7 @@ from wazo_confgend.hints.generator import HintGenerator
 from xivo_dao import asterisk_conf_dao
 
 
-class AsteriskFrontend(object):
+class AsteriskFrontend:
     def __init__(self, config, tpl_helper):
         self.contextsconf = config['templates']['contextsconf']
         self._tpl_helper = tpl_helper

--- a/wazo_confgend/bin/daemon.py
+++ b/wazo_confgend/bin/daemon.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/bin/daemon.py
+++ b/wazo_confgend/bin/daemon.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import xivo_dao
+import logging
 
 from twisted.application import service, internet
 from twisted.internet import reactor
@@ -10,6 +11,9 @@ from twisted.python import log
 from xivo import xivo_logging
 from wazo_confgend.confgen import ConfgendFactory
 from wazo_confgend.config import load as load_config
+
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -20,7 +24,9 @@ def main():
     xivo_dao.init_db(config['db_uri'])
     f = ConfgendFactory(config['cache'], config)
 
+    logger.info("Listening to TCP port %s on address %s", config['listen_port'], config['listen_address'])
     reactor.listenTCP(config['listen_port'], f, interface=config['listen_address'])
+    logger.info("Starting Twisted Reactor")
     reactor.run()
 
 

--- a/wazo_confgend/bin/daemon.py
+++ b/wazo_confgend/bin/daemon.py
@@ -19,12 +19,18 @@ logger = logging.getLogger(__name__)
 def main():
     config = load_config()
 
-    xivo_logging.setup_logging(config['log_filename'], debug=config['debug'], log_level=config['log_level'])
+    xivo_logging.setup_logging(
+        config['log_filename'], debug=config['debug'], log_level=config['log_level']
+    )
 
     xivo_dao.init_db(config['db_uri'])
     f = ConfgendFactory(config['cache'], config)
 
-    logger.info("Listening to TCP port %s on address %s", config['listen_port'], config['listen_address'])
+    logger.info(
+        "Listening to TCP port %s on address %s",
+        config['listen_port'],
+        config['listen_address'],
+    )
     reactor.listenTCP(config['listen_port'], f, interface=config['listen_address'])
     logger.info("Starting Twisted Reactor")
     reactor.run()
@@ -33,14 +39,18 @@ def main():
 def twisted_application():
     config = load_config()
 
-    xivo_logging.setup_logging(config['log_filename'], debug=config['debug'], log_level=config['log_level'])
+    xivo_logging.setup_logging(
+        config['log_filename'], debug=config['debug'], log_level=config['log_level']
+    )
 
     xivo_dao.init_db(config['db_uri'])
     f = ConfgendFactory(config['cache'], config)
 
     application = service.Application('confgend')
 
-    svc = internet.TCPServer(config['listen_port'], f, interface=config['listen_address'])
+    svc = internet.TCPServer(
+        config['listen_port'], f, interface=config['listen_address']
+    )
     svc.setServiceParent(application)
 
     return application

--- a/wazo_confgend/cache.py
+++ b/wazo_confgend/cache.py
@@ -3,12 +3,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import os.path
 
 
 class Cache(object):
-
     def get(self, key):
         raise NotImplementedError()
 
@@ -20,7 +18,6 @@ class Cache(object):
 
 
 class FileCache(Cache):
-
     def __init__(self, basedir):
         super(FileCache, self).__init__()
         self.basedir = basedir

--- a/wazo_confgend/cache.py
+++ b/wazo_confgend/cache.py
@@ -5,7 +5,7 @@
 import os.path
 
 
-class Cache(object):
+class Cache:
     def get(self, key):
         raise NotImplementedError()
 

--- a/wazo_confgend/cache.py
+++ b/wazo_confgend/cache.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/cache.py
+++ b/wazo_confgend/cache.py
@@ -2,7 +2,7 @@
 # Copyright 2010-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import os.path
 

--- a/wazo_confgend/cache.py
+++ b/wazo_confgend/cache.py
@@ -18,7 +18,7 @@ class Cache:
 
 class FileCache(Cache):
     def __init__(self, basedir):
-        super(FileCache, self).__init__()
+        super().__init__()
         self.basedir = basedir
 
     def get(self, key):

--- a/wazo_confgend/confgen.py
+++ b/wazo_confgend/confgen.py
@@ -101,7 +101,7 @@ class ConfgendFactory(ServerFactory):
             filename,
             args,
         )
-        cache_key = '{}/{}'.format(resource, filename)
+        cache_key = f'{resource}/{filename}'
         if 'invalidate' in args:
             self._cache.invalidate(cache_key)
         elif 'cached' in args:

--- a/wazo_confgend/confgen.py
+++ b/wazo_confgend/confgen.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging

--- a/wazo_confgend/confgen.py
+++ b/wazo_confgend/confgen.py
@@ -110,6 +110,6 @@ class ConfgendFactory(ServerFactory):
         if not content:
             return
 
-        encoded_content = content.encode('utf-8')
+        encoded_content = content
         self._cache.put(cache_key, encoded_content)
         return encoded_content

--- a/wazo_confgend/confgen.py
+++ b/wazo_confgend/confgen.py
@@ -2,7 +2,7 @@
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import logging
 import time

--- a/wazo_confgend/config.py
+++ b/wazo_confgend/config.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/config.py
+++ b/wazo_confgend/config.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
-
 from xivo.chain_map import ChainMap
 from xivo.config_helper import read_config_file_hierarchy
 from xivo.xivo_logging import get_log_level_by_name
@@ -27,7 +25,9 @@ _DEFAULT_CONFIG = {
 
 def load():
     file_config = read_config_file_hierarchy(_DEFAULT_CONFIG)
-    reinterpreted_config = _get_reinterpreted_raw_values(ChainMap(file_config, _DEFAULT_CONFIG))
+    reinterpreted_config = _get_reinterpreted_raw_values(
+        ChainMap(file_config, _DEFAULT_CONFIG)
+    )
     config = ChainMap(reinterpreted_config, file_config, _DEFAULT_CONFIG)
     return config
 

--- a/wazo_confgend/config.py
+++ b/wazo_confgend/config.py
@@ -2,8 +2,8 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
+
+
 
 from xivo.chain_map import ChainMap
 from xivo.config_helper import read_config_file_hierarchy

--- a/wazo_confgend/generators/__init__.py
+++ b/wazo_confgend/generators/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013-2014 Avencall
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import copy
 import configparser
-from UserDict import DictMixin
+from collections.abc import MutableMapping
 
 from xivo import xivo_helpers
 from xivo_dao import asterisk_conf_dao
@@ -51,7 +50,7 @@ DEFAULT_EXTENFEATURES = {
 }
 
 
-class CustomConfigParserStorage(DictMixin):
+class CustomConfigParserStorage(MutableMapping):
     def __init__(self, init=None):
         self._data = init if init else []
 
@@ -78,6 +77,9 @@ class CustomConfigParserStorage(DictMixin):
         if len(self._data) == n_items:
             raise KeyError
 
+    def __len__(self):
+        return len(self._data)
+
     def keys(self):
         return [k for k, v in self._data]
 
@@ -89,6 +91,10 @@ class CustomConfigParserStorage(DictMixin):
             yield k
 
     def iteritems(self):
+        # TODO: this can be deleted once all usages are refactored to items()
+        yield from self.items()
+
+    def items(self):
         for k, v in self._data:
             yield k, v
 

--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -82,7 +82,7 @@ class CustomConfigParser(configparser.RawConfigParser):
         ]
 
 
-class ExtensionGenerator(object):
+class ExtensionGenerator:
     def __init__(self, exten_row):
         self._exten_row = exten_row
 
@@ -131,7 +131,7 @@ extension_generators = {
 }
 
 
-class ExtensionsConf(object):
+class ExtensionsConf:
     def __init__(self, contextsconf, hint_generator, tpl_helper):
         self.contextsconf = contextsconf
         self.hint_generator = hint_generator

--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -2,10 +2,10 @@
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import copy
-import ConfigParser
+import configparser
 from UserDict import DictMixin
 
 from xivo import xivo_helpers
@@ -156,10 +156,10 @@ class ExtensionsConf(object):
 
         if self.contextsconf is not None:
             # load context templates
-            conf = ConfigParser.RawConfigParser(dict_type=CustomConfigParserStorage)
+            conf = configparser.RawConfigParser(dict_type=CustomConfigParserStorage)
             try:
                 conf.read([self.contextsconf])
-            except ConfigParser.DuplicateSectionError:
+            except configparser.DuplicateSectionError:
                 raise ValueError("%s has conflicting section names" % self.contextsconf)
             if not conf.has_section('template'):
                 raise ValueError("Template section doesn't exist in %s" % self.contextsconf)

--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -107,7 +107,7 @@ class IncallExtensionGenerator(ExtensionGenerator):
             'context': self._exten_row['context'],
             'exten': self._exten_row['exten'],
             'priority': '1',
-            'action': 'GoSub(did,s,1({},))'.format(self._exten_row['typeval']),
+            'action': f"GoSub(did,s,1({self._exten_row['typeval']},))",
         }
 
 
@@ -153,11 +153,11 @@ class ExtensionsConf:
                 with open(self.contextsconf) as contextsconf_file:
                     conf.read_file(contextsconf_file)
             except configparser.DuplicateSectionError:
-                raise ValueError("%s has conflicting section names" % self.contextsconf)
+                raise ValueError(f"{self.contextsconf} has conflicting section names")
 
             if not conf.has_section('template'):
                 raise ValueError(
-                    "Template section doesn't exist in %s" % self.contextsconf
+                    f"Template section doesn't exist in {self.contextsconf}"
                 )
 
         # hints & features (init)
@@ -185,14 +185,14 @@ class ExtensionsConf:
         for ctx in asterisk_conf_dao.find_context_settings():
             # context name preceded with '!' is ignored
             context_name = ctx['name']
-            if conf and conf.has_section('!%s' % context_name):
+            if conf and conf.has_section(f'!{context_name}'):
                 continue
             ast_writer.write_newline()
             ast_writer.write_section(context_name)
             if conf.has_section(context_name):
                 section = context_name
-            elif conf.has_section('type:%s' % ctx['contexttype']):
-                section = 'type:%s' % ctx['contexttype']
+            elif conf.has_section(f"type:{ctx['contexttype']}"):
+                section = f"type:{ctx['contexttype']}"
             else:
                 section = 'template'
 
@@ -247,14 +247,14 @@ class ExtensionsConf:
                 self.gen_dialplan_from_template(tmpl, exten, ast_writer)
 
         for x in ('busy', 'rna', 'unc'):
-            fwdtype = "fwd%s" % x
+            fwdtype = f"fwd{x}"
             if not xfeatures[fwdtype].get('commented', 1):
                 exten = xivo_helpers.clean_extension(xfeatures[fwdtype]['exten'])
                 cfeatures.extend(
                     [
                         "%s,1,Set(__XIVO_BASE_CONTEXT=${CONTEXT})" % exten,
                         "%s,n,Set(__XIVO_BASE_EXTEN=${EXTEN})" % exten,
-                        "%s,n,Gosub(feature_forward,s,1(%s))\n" % (exten, x),
+                        f"{exten},n,Gosub(feature_forward,s,1({x}))\n",
                     ]
                 )
 
@@ -277,17 +277,17 @@ class ExtensionsConf:
             line = line.replace('%%ACTION%%', str(exten.get('action', '')))
             line = line.replace('%%TENANT_UUID%%', str(exten.get('tenant_uuid', '')))
 
-            ast_writer.write_option(prefix, '{}{}'.format(padding, line))
+            ast_writer.write_option(prefix, f'{padding}{line}')
         ast_writer.write_newline()
 
     def _generate_global_hints(self, output):
         output.write('[usersharedlines]\n')
         for line in self.hint_generator.generate_global_hints():
-            output.write('{}\n'.format(line))
+            output.write(f'{line}\n')
 
     def _generate_hints(self, context, output):
         for line in self.hint_generator.generate(context):
-            output.write('{}\n'.format(line))
+            output.write(f'{line}\n')
 
     def _generate_ivr(self, output):
         for ivr in ivr_dao.find_all_by():
@@ -295,4 +295,4 @@ class ExtensionsConf:
             template = self._tpl_helper.get_customizable_template(
                 'asterisk/extensions/ivr', ivr.id
             )
-            output.write('{}\n'.format(template.dump(template_context)))
+            output.write(f'{template.dump(template_context)}\n')

--- a/wazo_confgend/generators/iax.py
+++ b/wazo_confgend/generators/iax.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 from xivo_dao import asterisk_conf_dao
 
 from wazo_confgend.generators.util import AsteriskFileWriter
@@ -55,7 +54,14 @@ class IaxConf(object):
     def _generate_trunk(self, trunk, ast_writer):
         ast_writer.write_section(trunk.name)
 
-        exclude_options = ('id', 'name', 'protocol', 'category', 'commented', 'disallow')
+        exclude_options = (
+            'id',
+            'name',
+            'protocol',
+            'category',
+            'commented',
+            'disallow',
+        )
         for k, v in trunk.all_options(exclude=exclude_options):
             if v in (None, ''):
                 continue

--- a/wazo_confgend/generators/iax.py
+++ b/wazo_confgend/generators/iax.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/iax.py
+++ b/wazo_confgend/generators/iax.py
@@ -47,7 +47,7 @@ class IaxConf:
         if self._call_limit_settings:
             ast_writer.write_section('callnumberlimits')
             for auth in self._call_limit_settings:
-                name = '{}/{}'.format(auth['destination'], auth['netmask'])
+                name = f"{auth['destination']}/{auth['netmask']}"
                 ast_writer.write_option(name, auth['calllimits'])
 
     def _generate_trunk(self, trunk, ast_writer):

--- a/wazo_confgend/generators/iax.py
+++ b/wazo_confgend/generators/iax.py
@@ -13,7 +13,7 @@ def write_allow_rules(allowed, ast_writer):
         ast_writer.write_option('allow', value)
 
 
-class IaxConf(object):
+class IaxConf:
     def __init__(self):
         self._general_settings = asterisk_conf_dao.find_iax_general_settings()
         self._call_limit_settings = asterisk_conf_dao.find_iax_calllimits_settings()

--- a/wazo_confgend/generators/iax.py
+++ b/wazo_confgend/generators/iax.py
@@ -2,7 +2,7 @@
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 from xivo_dao import asterisk_conf_dao
 
@@ -60,7 +60,7 @@ class IaxConf(object):
             if v in (None, ''):
                 continue
 
-            if isinstance(v, unicode):
+            if isinstance(v, str):
                 v = v.encode('utf8')
 
             if k == 'allow':

--- a/wazo_confgend/generators/iax.py
+++ b/wazo_confgend/generators/iax.py
@@ -60,9 +60,6 @@ class IaxConf(object):
             if v in (None, ''):
                 continue
 
-            if isinstance(v, str):
-                v = v.encode('utf8')
-
             if k == 'allow':
                 write_allow_rules(v, ast_writer)
             else:

--- a/wazo_confgend/generators/queues.py
+++ b/wazo_confgend/generators/queues.py
@@ -2,7 +2,7 @@
 # Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 from xivo_dao import asterisk_conf_dao
 
@@ -31,10 +31,10 @@ class QueuesConf(object):
         for q in asterisk_conf_dao.find_queue_settings():
             writer.write_section(q['name'], comment=q['label'])
 
-            for k, v in q.iteritems():
+            for k, v in q.items():
                 if k in self._ignored_keys:
                     continue
-                if v is None or (isinstance(v, basestring) and not v):
+                if v is None or (isinstance(v, str) and not v):
                     continue
 
                 if k == 'defaultrule':

--- a/wazo_confgend/generators/queues.py
+++ b/wazo_confgend/generators/queues.py
@@ -7,7 +7,7 @@ from xivo_dao import asterisk_conf_dao
 from wazo_confgend.generators.util import AsteriskFileWriter
 
 
-class QueuesConf(object):
+class QueuesConf:
 
     _ignored_keys = [
         'name',

--- a/wazo_confgend/generators/queues.py
+++ b/wazo_confgend/generators/queues.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/queues.py
+++ b/wazo_confgend/generators/queues.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 from xivo_dao import asterisk_conf_dao
 
 from wazo_confgend.generators.util import AsteriskFileWriter
@@ -44,6 +43,8 @@ class QueuesConf(object):
 
                 writer.write_option(k, v)
 
-            queuemember_settings = asterisk_conf_dao.find_queue_members_settings(q['name'])
+            queuemember_settings = asterisk_conf_dao.find_queue_members_settings(
+                q['name']
+            )
             for values in queuemember_settings:
                 writer.write_option('member', ','.join(values))

--- a/wazo_confgend/generators/res_parking.py
+++ b/wazo_confgend/generators/res_parking.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/res_parking.py
+++ b/wazo_confgend/generators/res_parking.py
@@ -7,7 +7,7 @@ from xivo_dao import asterisk_conf_dao
 from xivo_dao.resources.parking_lot import dao as parking_lot_dao
 
 
-class ResParkingConf(object):
+class ResParkingConf:
     def __init__(self):
         self._settings = asterisk_conf_dao.find_parking_settings()
         self._parking_lots = parking_lot_dao.find_all_by()

--- a/wazo_confgend/generators/res_parking.py
+++ b/wazo_confgend/generators/res_parking.py
@@ -3,14 +3,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 from wazo_confgend.generators.util import AsteriskFileWriter
 from xivo_dao import asterisk_conf_dao
 from xivo_dao.resources.parking_lot import dao as parking_lot_dao
 
 
 class ResParkingConf(object):
-
     def __init__(self):
         self._settings = asterisk_conf_dao.find_parking_settings()
         self._parking_lots = parking_lot_dao.find_all_by()
@@ -36,21 +34,25 @@ class ResParkingConf(object):
                 continue
 
             section = 'parkinglot-{}'.format(parking_lot.id)
-            options = [('parkext', parking_lot.extensions[0].exten),
-                       ('context', parking_lot.extensions[0].context),
-                       ('parkedmusicclass', parking_lot.music_on_hold or ''),
-                       ('parkpos', '{}-{}'.format(parking_lot.slots_start,
-                                                  parking_lot.slots_end)),
-                       ('parkingtime', parking_lot.timeout or 0),
-                       ('findslot', 'next'),
-                       ('parkext_exclusive', 'yes'),
-                       ('parkinghints', 'yes'),
-                       ('comebacktoorigin', 'yes'),
-                       ('parkedplay', 'caller'),
-                       ('parkedcalltransfers', 'no'),
-                       ('parkedcallreparking', 'no'),
-                       ('parkedcallhangup', 'no'),
-                       ('parkedcallrecording', 'no')]
+            options = [
+                ('parkext', parking_lot.extensions[0].exten),
+                ('context', parking_lot.extensions[0].context),
+                ('parkedmusicclass', parking_lot.music_on_hold or ''),
+                (
+                    'parkpos',
+                    '{}-{}'.format(parking_lot.slots_start, parking_lot.slots_end),
+                ),
+                ('parkingtime', parking_lot.timeout or 0),
+                ('findslot', 'next'),
+                ('parkext_exclusive', 'yes'),
+                ('parkinghints', 'yes'),
+                ('comebacktoorigin', 'yes'),
+                ('parkedplay', 'caller'),
+                ('parkedcalltransfers', 'no'),
+                ('parkedcallreparking', 'no'),
+                ('parkedcallhangup', 'no'),
+                ('parkedcallrecording', 'no'),
+            ]
 
             ast_file.write_section(section)
             ast_file.write_options(options)

--- a/wazo_confgend/generators/res_parking.py
+++ b/wazo_confgend/generators/res_parking.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 from wazo_confgend.generators.util import AsteriskFileWriter
 from xivo_dao import asterisk_conf_dao

--- a/wazo_confgend/generators/res_parking.py
+++ b/wazo_confgend/generators/res_parking.py
@@ -32,14 +32,14 @@ class ResParkingConf:
             if not parking_lot.extensions:
                 continue
 
-            section = 'parkinglot-{}'.format(parking_lot.id)
+            section = f'parkinglot-{parking_lot.id}'
             options = [
                 ('parkext', parking_lot.extensions[0].exten),
                 ('context', parking_lot.extensions[0].context),
                 ('parkedmusicclass', parking_lot.music_on_hold or ''),
                 (
                     'parkpos',
-                    '{}-{}'.format(parking_lot.slots_start, parking_lot.slots_end),
+                    f'{parking_lot.slots_start}-{parking_lot.slots_end}',
                 ),
                 ('parkingtime', parking_lot.timeout or 0),
                 ('findslot', 'next'),

--- a/wazo_confgend/generators/sccp.py
+++ b/wazo_confgend/generators/sccp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/sccp.py
+++ b/wazo_confgend/generators/sccp.py
@@ -2,7 +2,7 @@
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 from operator import itemgetter
 

--- a/wazo_confgend/generators/sccp.py
+++ b/wazo_confgend/generators/sccp.py
@@ -125,7 +125,7 @@ class _SccpDeviceConf:
         for item in self._sccpspeeddialdevices:
             if item['device'] == device:
                 ast_writer.write_option(
-                    'speeddial', '{:d}-{:d}'.format(item['user_id'], item['fknum'])
+                    'speeddial', f"{item['user_id']:d}-{item['fknum']:d}"
                 )
 
 
@@ -174,19 +174,15 @@ class _SccpLineConf:
                 'setvar',
                 'XIVO_ORIGINAL_CALLER_ID="{cid_name}" <{cid_num}>'.format(**item),
             )
-            ast_writer.write_option('setvar', 'XIVO_USERID={}'.format(item['user_id']))
-            ast_writer.write_option('setvar', 'XIVO_USERUUID={}'.format(item['uuid']))
-            ast_writer.write_option(
-                'setvar', 'WAZO_TENANT_UUID={}'.format(item['tenant_uuid'])
-            )
+            ast_writer.write_option('setvar', f"XIVO_USERID={item['user_id']}")
+            ast_writer.write_option('setvar', f"XIVO_USERUUID={item['uuid']}")
+            ast_writer.write_option('setvar', f"WAZO_TENANT_UUID={item['tenant_uuid']}")
             ast_writer.write_option(
                 'setvar', 'PICKUPMARK={number}%{context}'.format(**item)
             )
-            ast_writer.write_option(
-                'setvar', 'TRANSFER_CONTEXT={}'.format(item['context'])
-            )
+            ast_writer.write_option('setvar', f"TRANSFER_CONTEXT={item['context']}")
             ast_writer.write_option('setvar', 'WAZO_CHANNEL_DIRECTION=from-wazo')
-            ast_writer.write_option('setvar', 'WAZO_LINE_ID={}'.format(item['id']))
+            ast_writer.write_option('setvar', f"WAZO_LINE_ID={item['id']}")
             if item['enable_online_recording']:
                 ast_writer.write_option('setvar', 'DYNAMIC_FEATURES=togglerecord')
             if item['language']:
@@ -211,7 +207,7 @@ class _SccpSpeedDialConf:
     def generate(self, sccpspeeddial, output):
         ast_writer = AsteriskFileWriter(output)
         for item in sccpspeeddial:
-            ast_writer.write_section('{:d}-{:d}'.format(item['user_id'], item['fknum']))
+            ast_writer.write_section(f"{item['user_id']:d}-{item['fknum']:d}")
             ast_writer.write_option('type', 'speeddial')
             ast_writer.write_option('extension', item['exten'])
             if item['label']:

--- a/wazo_confgend/generators/sccp.py
+++ b/wazo_confgend/generators/sccp.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 from operator import itemgetter
 
 from wazo_confgend.generators.util import AsteriskFileWriter
@@ -14,7 +13,6 @@ _GUEST_LINE_NAME = 'guestline'
 
 
 class SccpConf(object):
-
     def __init__(self):
         self._sccpgeneralsettings = asterisk_conf_dao.find_sccp_general_settings()
         self._sccpline = asterisk_conf_dao.find_sccp_line_settings()
@@ -22,13 +20,17 @@ class SccpConf(object):
         self._sccpspeeddial = asterisk_conf_dao.find_sccp_speeddial_settings()
 
     def generate(self, output):
-        splitted_settings = _SplittedGeneralSettings.new_from_dao_general_settings(self._sccpgeneralsettings)
+        splitted_settings = _SplittedGeneralSettings.new_from_dao_general_settings(
+            self._sccpgeneralsettings
+        )
 
         sccp_general_conf = _SccpGeneralSettingsConf()
         sccp_general_conf.generate(splitted_settings.general_items, output)
 
         sccp_device_conf = _SccpDeviceConf(self._sccpspeeddial)
-        sccp_device_conf.generate(self._sccpdevice, splitted_settings.device_items, output)
+        sccp_device_conf.generate(
+            self._sccpdevice, splitted_settings.device_items, output
+        )
 
         sccp_line_conf = _SccpLineConf()
         sccp_line_conf.generate(self._sccpline, splitted_settings.line_items, output)
@@ -40,7 +42,14 @@ class SccpConf(object):
 class _SplittedGeneralSettings(object):
 
     _DEVICE_OPTIONS = ['dialtimeout', 'dateformat', 'vmexten', 'keepalive']
-    _LINES_OPTIONS = ['context', 'language', 'directmedia', 'tos_audio', 'disallow', 'allow']
+    _LINES_OPTIONS = [
+        'context',
+        'language',
+        'directmedia',
+        'tos_audio',
+        'disallow',
+        'allow',
+    ]
 
     def __init__(self, general_items, device_items, line_items):
         self.general_items = general_items
@@ -66,7 +75,6 @@ class _SplittedGeneralSettings(object):
 
 
 class _SccpGeneralSettingsConf(object):
-
     def generate(self, general_items, output):
         ast_writer = AsteriskFileWriter(output)
         ast_writer.write_section('general')
@@ -117,7 +125,9 @@ class _SccpDeviceConf(object):
     def _generate_speeddials(self, device, ast_writer):
         for item in self._sccpspeeddialdevices:
             if item['device'] == device:
-                ast_writer.write_option('speeddial', '{:d}-{:d}'.format(item['user_id'], item['fknum']))
+                ast_writer.write_option(
+                    'speeddial', '{:d}-{:d}'.format(item['user_id'], item['fknum'])
+                )
 
 
 class _SccpLineConf(object):
@@ -161,12 +171,21 @@ class _SccpLineConf(object):
             ast_writer.write_option('type', 'line')
             ast_writer.write_option('cid_name', item['cid_name'])
             ast_writer.write_option('cid_num', item['cid_num'])
-            ast_writer.write_option('setvar', 'XIVO_ORIGINAL_CALLER_ID="{cid_name}" <{cid_num}>'.format(**item))
+            ast_writer.write_option(
+                'setvar',
+                'XIVO_ORIGINAL_CALLER_ID="{cid_name}" <{cid_num}>'.format(**item),
+            )
             ast_writer.write_option('setvar', 'XIVO_USERID={}'.format(item['user_id']))
             ast_writer.write_option('setvar', 'XIVO_USERUUID={}'.format(item['uuid']))
-            ast_writer.write_option('setvar', 'WAZO_TENANT_UUID={}'.format(item['tenant_uuid']))
-            ast_writer.write_option('setvar', 'PICKUPMARK={number}%{context}'.format(**item))
-            ast_writer.write_option('setvar', 'TRANSFER_CONTEXT={}'.format(item['context']))
+            ast_writer.write_option(
+                'setvar', 'WAZO_TENANT_UUID={}'.format(item['tenant_uuid'])
+            )
+            ast_writer.write_option(
+                'setvar', 'PICKUPMARK={number}%{context}'.format(**item)
+            )
+            ast_writer.write_option(
+                'setvar', 'TRANSFER_CONTEXT={}'.format(item['context'])
+            )
             ast_writer.write_option('setvar', 'WAZO_CHANNEL_DIRECTION=from-wazo')
             ast_writer.write_option('setvar', 'WAZO_LINE_ID={}'.format(item['id']))
             if item['enable_online_recording']:
@@ -179,9 +198,13 @@ class _SccpLineConf(object):
             if 'allow' in item:
                 ast_writer.write_option('allow', item['allow'])
             if 'callgroup' in item:
-                ast_writer.write_option('namedcallgroup', ','.join(map(str, item['callgroup'])))
+                ast_writer.write_option(
+                    'namedcallgroup', ','.join(map(str, item['callgroup']))
+                )
             if 'pickupgroup' in item:
-                ast_writer.write_option('namedpickupgroup', ','.join(map(str, item['pickupgroup'])))
+                ast_writer.write_option(
+                    'namedpickupgroup', ','.join(map(str, item['pickupgroup']))
+                )
             ast_writer.write_newline()
 
 

--- a/wazo_confgend/generators/sccp.py
+++ b/wazo_confgend/generators/sccp.py
@@ -11,7 +11,7 @@ _GUEST_DEVICE_NAME = 'guest'
 _GUEST_LINE_NAME = 'guestline'
 
 
-class SccpConf(object):
+class SccpConf:
     def __init__(self):
         self._sccpgeneralsettings = asterisk_conf_dao.find_sccp_general_settings()
         self._sccpline = asterisk_conf_dao.find_sccp_line_settings()
@@ -38,7 +38,7 @@ class SccpConf(object):
         sccp_speeddial_conf.generate(self._sccpspeeddial, output)
 
 
-class _SplittedGeneralSettings(object):
+class _SplittedGeneralSettings:
 
     _DEVICE_OPTIONS = ['dialtimeout', 'dateformat', 'vmexten', 'keepalive']
     _LINES_OPTIONS = [
@@ -73,7 +73,7 @@ class _SplittedGeneralSettings(object):
         return cls(general_items, device_items, line_items)
 
 
-class _SccpGeneralSettingsConf(object):
+class _SccpGeneralSettingsConf:
     def generate(self, general_items, output):
         ast_writer = AsteriskFileWriter(output)
         ast_writer.write_section('general')
@@ -82,7 +82,7 @@ class _SccpGeneralSettingsConf(object):
         ast_writer.write_newline()
 
 
-class _SccpDeviceConf(object):
+class _SccpDeviceConf:
 
     _TPL_NAME = 'xivo_device_tpl'
 
@@ -129,7 +129,7 @@ class _SccpDeviceConf(object):
                 )
 
 
-class _SccpLineConf(object):
+class _SccpLineConf:
 
     _TPL_NAME = 'xivo_line_tpl'
 
@@ -207,7 +207,7 @@ class _SccpLineConf(object):
             ast_writer.write_newline()
 
 
-class _SccpSpeedDialConf(object):
+class _SccpSpeedDialConf:
     def generate(self, sccpspeeddial, output):
         ast_writer = AsteriskFileWriter(output)
         for item in sccpspeeddial:

--- a/wazo_confgend/generators/tests/__init__.py
+++ b/wazo_confgend/generators/tests/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013-2014 Avencall
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_confgend/generators/tests/test_extensionsconf.py
+++ b/wazo_confgend/generators/tests/test_extensionsconf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/tests/test_extensionsconf.py
+++ b/wazo_confgend/generators/tests/test_extensionsconf.py
@@ -2,12 +2,12 @@
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import os
 import unittest
 import textwrap
-from StringIO import StringIO
+from io import StringIO
 
 from hamcrest import assert_that, contains_string
 from mock import Mock, patch

--- a/wazo_confgend/generators/tests/test_extensionsconf.py
+++ b/wazo_confgend/generators/tests/test_extensionsconf.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import os
 import unittest
 import textwrap
@@ -28,7 +27,9 @@ class TestExtensionsConf(unittest.TestCase):
         self.tpl_mapping = {}
         self.tpl_helper = TemplateHelper(DictLoader(self.tpl_mapping))
         self.extensionsconf = ExtensionsConf(
-            'etc/wazo-confgend/templates/contexts.conf', self.hint_generator, self.tpl_helper
+            'etc/wazo-confgend/templates/contexts.conf',
+            self.hint_generator,
+            self.tpl_helper,
         )
         self.output = StringIO()
 
@@ -39,28 +40,53 @@ class TestExtensionsConf(unittest.TestCase):
             ('objtpl', '%%EXTEN%%,%%PRIORITY%%,Set(__XIVO_BASE_CONTEXT=${CONTEXT})'),
             ('objtpl', 'n,Set(__XIVO_BASE_EXTEN=${EXTEN})'),
             ('objtpl', 'n,GoSub(contextlib,entry-exten-context,1)'),
-            ('objtpl', 'n,%%ACTION%%')
+            ('objtpl', 'n,%%ACTION%%'),
         ]
         xfeatures = {
-            'fwdrna': {'exten': '_*22.', 'commented': 0}, 'fwdbusy': {'exten': '_*23.', 'commented': 0},
-            'bsfilter': {'exten': '_*37.', 'commented': 0}, 'fwdunc': {'exten': '_*21.', 'commented': 0},
+            'fwdrna': {'exten': '_*22.', 'commented': 0},
+            'fwdbusy': {'exten': '_*23.', 'commented': 0},
+            'bsfilter': {'exten': '_*37.', 'commented': 0},
+            'fwdunc': {'exten': '_*21.', 'commented': 0},
             'vmusermsg': {'exten': '*98', 'commented': 0},
-            'phoneprogfunckey': {'exten': '_*735.', 'commented': 0}
+            'phoneprogfunckey': {'exten': '_*735.', 'commented': 0},
         }
         mock_find_exten_xivofeatures_setting.return_value = [
-            {'exten': '*10', 'commented': 0, 'context': 'xivo-features', 'typeval': 'phonestatus',
-             'type': 'extenfeatures', 'id': 17},
-            {'exten': '_*11.', 'commented': 0, 'context': 'xivo-features', 'typeval': 'paging',
-             'type': 'extenfeatures', 'id': 28},
-            {'exten': '*20', 'commented': 0, 'context': 'xivo-features', 'typeval': 'fwdundoall',
-             'type': 'extenfeatures', 'id': 14},
+            {
+                'exten': '*10',
+                'commented': 0,
+                'context': 'xivo-features',
+                'typeval': 'phonestatus',
+                'type': 'extenfeatures',
+                'id': 17,
+            },
+            {
+                'exten': '_*11.',
+                'commented': 0,
+                'context': 'xivo-features',
+                'typeval': 'paging',
+                'type': 'extenfeatures',
+                'id': 28,
+            },
+            {
+                'exten': '*20',
+                'commented': 0,
+                'context': 'xivo-features',
+                'typeval': 'fwdundoall',
+                'type': 'extenfeatures',
+                'id': 14,
+            },
         ]
 
         ast_writer = AsteriskFileWriter(self.output)
-        self.extensionsconf._generate_extension_features(mock_conf, xfeatures, ast_writer)
+        self.extensionsconf._generate_extension_features(
+            mock_conf, xfeatures, ast_writer
+        )
         mock_conf.items.assert_called_once_with('xivo-features')
         mock_find_exten_xivofeatures_setting.assert_called_once()
-        self.assertEqual(self.output.getvalue(), textwrap.dedent("""\
+        self.assertEqual(
+            self.output.getvalue(),
+            textwrap.dedent(
+                """\
             [xivo-features]
             exten = *10,1,Set(__XIVO_BASE_CONTEXT=${CONTEXT})
             same  =     n,Set(__XIVO_BASE_EXTEN=${EXTEN})
@@ -86,7 +112,9 @@ class TestExtensionsConf(unittest.TestCase):
             exten = *21,1,Set(__XIVO_BASE_CONTEXT=${CONTEXT})
             exten = *21,n,Set(__XIVO_BASE_EXTEN=${EXTEN})
             exten = *21,n,Gosub(feature_forward,s,1(unc))
-        """))
+        """
+            ),
+        )
 
     def test_generate_dialplan_from_template(self):
         template = ["%%EXTEN%%,%%PRIORITY%%,Set('__XIVO_BASE_CONTEXT': ${CONTEXT})"]
@@ -95,7 +123,10 @@ class TestExtensionsConf(unittest.TestCase):
         ast_writer = AsteriskFileWriter(self.output)
         self.extensionsconf.gen_dialplan_from_template(template, exten, ast_writer)
 
-        self.assertEqual(self.output.getvalue(), "exten = *98,1,Set('__XIVO_BASE_CONTEXT': ${CONTEXT})\n\n")
+        self.assertEqual(
+            self.output.getvalue(),
+            "exten = *98,1,Set('__XIVO_BASE_CONTEXT': ${CONTEXT})\n\n",
+        )
 
     def test_generate_hints(self):
         hints = [
@@ -116,15 +147,20 @@ class TestExtensionsConf(unittest.TestCase):
     def test_generate_ivrs(self, mock_ivr_dao):
         ivr = IVR(id=42, name='foo', menu_sound='héllo-world')
         mock_ivr_dao.find_all_by.return_value = [ivr]
-        self.tpl_mapping['asterisk/extensions/ivr.jinja'] = textwrap.dedent('''
+        self.tpl_mapping['asterisk/extensions/ivr.jinja'] = textwrap.dedent(
+            '''
             [xivo-ivr-{{ ivr.id }}]
             same  =   n,Background({{ ivr.menu_sound }})
-        ''')
+        '''
+        )
 
         self.extensionsconf._generate_ivr(self.output)
 
         assert_that(self.output.getvalue(), contains_string('[xivo-ivr-42]'))
-        assert_that(self.output.getvalue(), contains_string('same  =   n,Background(héllo-world)'))
+        assert_that(
+            self.output.getvalue(),
+            contains_string('same  =   n,Background(héllo-world)'),
+        )
 
     @patch('wazo_confgend.generators.extensionsconf.ivr_dao')
     @patch('wazo_confgend.generators.extensionsconf.asterisk_conf_dao')
@@ -151,16 +187,36 @@ class TestExtensionsConf(unittest.TestCase):
 
         mock_asterisk_conf_dao.find_context_settings.return_value = [
             {"name": "ctx_name", "contexttype": "incall", "tenant_uuid": "tenant-uuid"},
-            {"name": "ctx_internal", "contexttype": "internal", "tenant_uuid": "tenant-uuid"},
+            {
+                "name": "ctx_internal",
+                "contexttype": "internal",
+                "tenant_uuid": "tenant-uuid",
+            },
         ]
         mock_asterisk_conf_dao.find_contextincludes_settings.return_value = [
             {"include": "include-me.conf"}
         ]
         mock_asterisk_conf_dao.find_exten_settings.side_effect = [
-            [{"type": "incall", "context": "default", "exten": "foo@bar", "typeval":
-             "incallfilter", "id": 1234, "tenant_uuid": "2b853b5b-6c19-4123-90da-3ce05fe9aa74"}],
-            [{"type": "user", "context": "ctx_internal", "exten": "user@ctx_internal", "typeval":
-             "user", "id": 56, "tenant_uuid": "5adadf7b-5a4c-4701-9486-a4e8f9d21db0"}],
+            [
+                {
+                    "type": "incall",
+                    "context": "default",
+                    "exten": "foo@bar",
+                    "typeval": "incallfilter",
+                    "id": 1234,
+                    "tenant_uuid": "2b853b5b-6c19-4123-90da-3ce05fe9aa74",
+                }
+            ],
+            [
+                {
+                    "type": "user",
+                    "context": "ctx_internal",
+                    "exten": "user@ctx_internal",
+                    "typeval": "user",
+                    "id": 56,
+                    "tenant_uuid": "5adadf7b-5a4c-4701-9486-a4e8f9d21db0",
+                }
+            ],
         ]
 
         self.extensionsconf.generate(self.output)

--- a/wazo_confgend/generators/tests/test_iax.py
+++ b/wazo_confgend/generators/tests/test_iax.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 
 from mock import patch, Mock
@@ -12,33 +11,89 @@ from wazo_confgend.generators.tests.util import assert_generates_config
 
 
 class TestIaxConf(unittest.TestCase):
-    @patch('xivo_dao.asterisk_conf_dao.find_iax_general_settings', Mock(return_value=[]))
-    @patch('xivo_dao.asterisk_conf_dao.find_iax_calllimits_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_iax_general_settings', Mock(return_value=[])
+    )
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_iax_calllimits_settings', Mock(return_value=[])
+    )
     @patch('xivo_dao.asterisk_conf_dao.find_iax_trunk_settings', Mock(return_value=[]))
     def test_empty_sections(self):
         iax_conf = IaxConf()
-        assert_generates_config(iax_conf, '''
+        assert_generates_config(
+            iax_conf,
+            '''
             [general]
-        ''')
+        ''',
+        )
 
     @patch('xivo_dao.asterisk_conf_dao.find_iax_general_settings')
-    @patch('xivo_dao.asterisk_conf_dao.find_iax_calllimits_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_iax_calllimits_settings', Mock(return_value=[])
+    )
     @patch('xivo_dao.asterisk_conf_dao.find_iax_trunk_settings', Mock(return_value=[]))
     def test_general_section(self, find_iax_general_settings):
         find_iax_general_settings.return_value = [
-            {'filename': 'iax.conf', 'category': 'general', 'var_name': 'bindport', 'var_val': '4569'},
-            {'filename': 'iax.conf', 'category': 'general', 'var_name': 'bindaddr', 'var_val': '0.0.0.0'},
-            {'filename': 'iax.conf', 'category': 'general', 'var_name': 'iaxcompat', 'var_val': 'no'},
-            {'filename': 'iax.conf', 'category': 'general', 'var_name': 'authdebug', 'var_val': 'yes'},
-            {'filename': 'iax.conf', 'category': 'general', 'var_name': 'srvlookup', 'var_val': None},
-            {'filename': 'iax.conf', 'category': 'general', 'var_name': 'shrinkcallerid', 'var_val': None},
-            {'filename': 'iax.conf', 'category': 'general', 'var_name': 'language', 'var_val': 'fr_FR'},
-            {'filename': 'iax.conf', 'category': 'general', 'var_name': 'register', 'var_val': 'user:secret@host'},
-            {'filename': 'iax.conf', 'category': 'general', 'var_name': 'allow', 'var_val': 'gsm,ulaw,alaw'},
+            {
+                'filename': 'iax.conf',
+                'category': 'general',
+                'var_name': 'bindport',
+                'var_val': '4569',
+            },
+            {
+                'filename': 'iax.conf',
+                'category': 'general',
+                'var_name': 'bindaddr',
+                'var_val': '0.0.0.0',
+            },
+            {
+                'filename': 'iax.conf',
+                'category': 'general',
+                'var_name': 'iaxcompat',
+                'var_val': 'no',
+            },
+            {
+                'filename': 'iax.conf',
+                'category': 'general',
+                'var_name': 'authdebug',
+                'var_val': 'yes',
+            },
+            {
+                'filename': 'iax.conf',
+                'category': 'general',
+                'var_name': 'srvlookup',
+                'var_val': None,
+            },
+            {
+                'filename': 'iax.conf',
+                'category': 'general',
+                'var_name': 'shrinkcallerid',
+                'var_val': None,
+            },
+            {
+                'filename': 'iax.conf',
+                'category': 'general',
+                'var_name': 'language',
+                'var_val': 'fr_FR',
+            },
+            {
+                'filename': 'iax.conf',
+                'category': 'general',
+                'var_name': 'register',
+                'var_val': 'user:secret@host',
+            },
+            {
+                'filename': 'iax.conf',
+                'category': 'general',
+                'var_name': 'allow',
+                'var_val': 'gsm,ulaw,alaw',
+            },
         ]
 
         iax_conf = IaxConf()
-        assert_generates_config(iax_conf, '''
+        assert_generates_config(
+            iax_conf,
+            '''
             [general]
             bindport = 4569
             bindaddr = 0.0.0.0
@@ -50,29 +105,49 @@ class TestIaxConf(unittest.TestCase):
             allow = gsm
             allow = ulaw
             allow = alaw
-        ''')
+        ''',
+        )
         find_iax_general_settings.assert_called_once_with()
 
-    @patch('xivo_dao.asterisk_conf_dao.find_iax_general_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_iax_general_settings', Mock(return_value=[])
+    )
     @patch('xivo_dao.asterisk_conf_dao.find_iax_calllimits_settings')
     @patch('xivo_dao.asterisk_conf_dao.find_iax_trunk_settings', Mock(return_value=[]))
     def test_call_limits_section(self, find_iax_calllimits_settings):
         find_iax_calllimits_settings.return_value = [
-            {'id': 1, 'destination': '192.168.2.1', 'netmask': '255.255.255.0', 'calllimits': 10},
-            {'id': 1, 'destination': '10.0.0.1', 'netmask': '255.255.255.255', 'calllimits': 100},
+            {
+                'id': 1,
+                'destination': '192.168.2.1',
+                'netmask': '255.255.255.0',
+                'calllimits': 10,
+            },
+            {
+                'id': 1,
+                'destination': '10.0.0.1',
+                'netmask': '255.255.255.255',
+                'calllimits': 100,
+            },
         ]
 
         iax_conf = IaxConf()
-        assert_generates_config(iax_conf, '''
+        assert_generates_config(
+            iax_conf,
+            '''
             [general]
             [callnumberlimits]
             192.168.2.1/255.255.255.0 = 10
             10.0.0.1/255.255.255.255 = 100
-        ''')
+        ''',
+        )
         find_iax_calllimits_settings.assert_called_once_with()
 
-    @patch('xivo_dao.asterisk_conf_dao.find_iax_general_settings', Mock(return_value=[]))
-    @patch('xivo_dao.asterisk_conf_dao.find_iax_calllimits_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_iax_general_settings', Mock(return_value=[])
+    )
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_iax_calllimits_settings', Mock(return_value=[])
+    )
     @patch('xivo_dao.asterisk_conf_dao.find_iax_trunk_settings')
     def test_trunk_section(self, find_iax_trunk_settings):
         trunk = Mock()
@@ -131,7 +206,9 @@ class TestIaxConf(unittest.TestCase):
         find_iax_trunk_settings.return_value = [trunk]
 
         iax_conf = IaxConf()
-        assert_generates_config(iax_conf, '''
+        assert_generates_config(
+            iax_conf,
+            '''
             [general]
             [wazo_devel_51]
             type = friend
@@ -151,5 +228,6 @@ class TestIaxConf(unittest.TestCase):
             category = trunk
             commented = 0
             requirecalltoken = auto
-        ''')
+        ''',
+        )
         find_iax_trunk_settings.assert_called_once_with()

--- a/wazo_confgend/generators/tests/test_iax.py
+++ b/wazo_confgend/generators/tests/test_iax.py
@@ -2,7 +2,7 @@
 # Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 

--- a/wazo_confgend/generators/tests/test_iax.py
+++ b/wazo_confgend/generators/tests/test_iax.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/tests/test_queues.py
+++ b/wazo_confgend/generators/tests/test_queues.py
@@ -2,7 +2,7 @@
 # Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 

--- a/wazo_confgend/generators/tests/test_queues.py
+++ b/wazo_confgend/generators/tests/test_queues.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/tests/test_queues.py
+++ b/wazo_confgend/generators/tests/test_queues.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 
 from mock import patch, Mock
@@ -12,21 +11,33 @@ from wazo_confgend.generators.tests.util import assert_generates_config
 
 
 class TestQueuesConf(unittest.TestCase):
-
     def setUp(self):
         self.queues_conf = QueuesConf()
 
-    @patch('xivo_dao.asterisk_conf_dao.find_queue_penalty_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_queue_penalty_settings', Mock(return_value=[])
+    )
     @patch('xivo_dao.asterisk_conf_dao.find_queue_settings', Mock(return_value=[]))
-    @patch('xivo_dao.asterisk_conf_dao.find_queue_general_settings', Mock(return_value=[]))
-    @patch('xivo_dao.asterisk_conf_dao.find_queue_members_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_queue_general_settings', Mock(return_value=[])
+    )
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_queue_members_settings', Mock(return_value=[])
+    )
     def test_empty_sections(self):
-        assert_generates_config(self.queues_conf, '''
+        assert_generates_config(
+            self.queues_conf,
+            '''
             [general]
-        ''')
+        ''',
+        )
 
-    @patch('xivo_dao.asterisk_conf_dao.find_queue_members_settings', Mock(return_value=[]))
-    @patch('xivo_dao.asterisk_conf_dao.find_queue_penalty_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_queue_members_settings', Mock(return_value=[])
+    )
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_queue_penalty_settings', Mock(return_value=[])
+    )
     @patch('xivo_dao.asterisk_conf_dao.find_queue_settings', Mock(return_value=[]))
     @patch('xivo_dao.asterisk_conf_dao.find_queue_general_settings')
     def test_general_section(self, find_queue_general_settings):
@@ -34,14 +45,21 @@ class TestQueuesConf(unittest.TestCase):
             {'var_name': 'autofill', 'var_val': 'no'},
         ]
 
-        assert_generates_config(self.queues_conf, '''
+        assert_generates_config(
+            self.queues_conf,
+            '''
             [general]
             autofill = no
-        ''')
+        ''',
+        )
         find_queue_general_settings.assert_called_once_with()
 
-    @patch('xivo_dao.asterisk_conf_dao.find_queue_penalty_settings', Mock(return_value=[]))
-    @patch('xivo_dao.asterisk_conf_dao.find_queue_general_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_queue_penalty_settings', Mock(return_value=[])
+    )
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_queue_general_settings', Mock(return_value=[])
+    )
     @patch('xivo_dao.asterisk_conf_dao.find_queue_settings')
     @patch('xivo_dao.asterisk_conf_dao.find_queue_members_settings')
     def test_queues_section(self, find_queue_members_settings, find_queue_settings):
@@ -59,7 +77,9 @@ class TestQueuesConf(unittest.TestCase):
             ('iface', '2', 'name', 'state_iface'),
         ]
 
-        assert_generates_config(self.queues_conf, '''
+        assert_generates_config(
+            self.queues_conf,
+            '''
             [general]
 
             ; group 1
@@ -67,6 +87,9 @@ class TestQueuesConf(unittest.TestCase):
             wrapuptime = 0
             member = PJSIP/abc,1,,
             member = iface,2,name,state_iface
-        ''')
+        ''',
+        )
         find_queue_settings.assert_called_once_with()
-        find_queue_members_settings.assert_called_once_with('grp-supertenant-42f6b00e-0181-427b-b885-cf0b95893762')
+        find_queue_members_settings.assert_called_once_with(
+            'grp-supertenant-42f6b00e-0181-427b-b885-cf0b95893762'
+        )

--- a/wazo_confgend/generators/tests/test_res_parking.py
+++ b/wazo_confgend/generators/tests/test_res_parking.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/tests/test_res_parking.py
+++ b/wazo_confgend/generators/tests/test_res_parking.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 
 from mock import patch, Mock
@@ -12,10 +11,10 @@ from wazo_confgend.generators.tests.util import assert_generates_config
 
 
 class TestResParkingConf(unittest.TestCase):
-
     def _new_conf(self, settings, parking_lots=None):
-        with patch('xivo_dao.asterisk_conf_dao.find_parking_settings'), \
-                patch('xivo_dao.resources.parking_lot.dao.find_all_by'):
+        with patch('xivo_dao.asterisk_conf_dao.find_parking_settings'), patch(
+            'xivo_dao.resources.parking_lot.dao.find_all_by'
+        ):
             conf = ResParkingConf()
             conf._settings = settings
             conf._parking_lots = parking_lots or []
@@ -29,44 +28,50 @@ class TestResParkingConf(unittest.TestCase):
 
         res_parking_conf = self._new_conf(settings)
 
-        assert_generates_config(res_parking_conf, '''
+        assert_generates_config(
+            res_parking_conf,
+            '''
             [general]
-        ''')
+        ''',
+        )
 
     def test_settings(self):
         settings = {
             'general_options': [('parkeddynamic', 'no')],
-            'parking_lots': [{
-                'name': 'default',
-                'options': [('parkext', '700')]
-            }],
+            'parking_lots': [{'name': 'default', 'options': [('parkext', '700')]}],
         }
 
         res_parking_conf = self._new_conf(settings)
 
-        assert_generates_config(res_parking_conf, '''
+        assert_generates_config(
+            res_parking_conf,
+            '''
             [general]
             parkeddynamic = no
 
             [default]
             parkext = 700
-        ''')
+        ''',
+        )
 
     def test_settings_with_parking_lots(self):
-        settings = {
-            'general_options': [],
-            'parking_lots': []
-        }
-        parking_lots = [Mock(id=1,
-                             slots_start='801',
-                             slots_end='850',
-                             extensions=[Mock(exten='800', context='default')],
-                             music_on_hold='music_class',
-                             timeout=60)]
+        settings = {'general_options': [], 'parking_lots': []}
+        parking_lots = [
+            Mock(
+                id=1,
+                slots_start='801',
+                slots_end='850',
+                extensions=[Mock(exten='800', context='default')],
+                music_on_hold='music_class',
+                timeout=60,
+            )
+        ]
 
         res_parking_conf = self._new_conf(settings, parking_lots)
 
-        assert_generates_config(res_parking_conf, '''
+        assert_generates_config(
+            res_parking_conf,
+            '''
             [general]
 
             [parkinglot-1]
@@ -84,23 +89,27 @@ class TestResParkingConf(unittest.TestCase):
             parkedcallreparking = no
             parkedcallhangup = no
             parkedcallrecording = no
-        ''')
+        ''',
+        )
 
     def test_parking_lots_with_none_values(self):
-        settings = {
-            'general_options': [],
-            'parking_lots': []
-        }
-        parking_lots = [Mock(id=1,
-                             slots_start='801',
-                             slots_end='850',
-                             extensions=[Mock(exten='800', context='default')],
-                             music_on_hold=None,
-                             timeout=None)]
+        settings = {'general_options': [], 'parking_lots': []}
+        parking_lots = [
+            Mock(
+                id=1,
+                slots_start='801',
+                slots_end='850',
+                extensions=[Mock(exten='800', context='default')],
+                music_on_hold=None,
+                timeout=None,
+            )
+        ]
 
         res_parking_conf = self._new_conf(settings, parking_lots)
 
-        assert_generates_config(res_parking_conf, '''
+        assert_generates_config(
+            res_parking_conf,
+            '''
             [general]
 
             [parkinglot-1]
@@ -118,4 +127,5 @@ class TestResParkingConf(unittest.TestCase):
             parkedcallreparking = no
             parkedcallhangup = no
             parkedcallrecording = no
-        ''')
+        ''',
+        )

--- a/wazo_confgend/generators/tests/test_res_parking.py
+++ b/wazo_confgend/generators/tests/test_res_parking.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 

--- a/wazo_confgend/generators/tests/test_sccp.py
+++ b/wazo_confgend/generators/tests/test_sccp.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/tests/test_sccp.py
+++ b/wazo_confgend/generators/tests/test_sccp.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import itertools
 import io
 import unittest
@@ -11,26 +10,41 @@ import unittest
 from mock import Mock, patch
 from uuid import uuid4
 
-from wazo_confgend.generators.tests.util import assert_generates_config,\
-    assert_config_equal
+from wazo_confgend.generators.tests.util import (
+    assert_generates_config,
+    assert_config_equal,
+)
 
-from wazo_confgend.generators.sccp import SccpConf, _SccpGeneralSettingsConf, _SccpLineConf, _SccpDeviceConf, \
-    _SccpSpeedDialConf, _SplittedGeneralSettings
+from wazo_confgend.generators.sccp import (
+    SccpConf,
+    _SccpGeneralSettingsConf,
+    _SccpLineConf,
+    _SccpDeviceConf,
+    _SccpSpeedDialConf,
+    _SplittedGeneralSettings,
+)
 from wazo_confgend.generators.util import AsteriskFileWriter
 
 
 class TestSccpConf(unittest.TestCase):
-
-    @patch('xivo_dao.asterisk_conf_dao.find_sccp_general_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_sccp_general_settings', Mock(return_value=[])
+    )
     @patch('xivo_dao.asterisk_conf_dao.find_sccp_line_settings', Mock(return_value=[]))
-    @patch('xivo_dao.asterisk_conf_dao.find_sccp_device_settings', Mock(return_value=[]))
-    @patch('xivo_dao.asterisk_conf_dao.find_sccp_speeddial_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_sccp_device_settings', Mock(return_value=[])
+    )
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_sccp_speeddial_settings', Mock(return_value=[])
+    )
     def setUp(self):
         self._output = io.StringIO()
         self._conf = SccpConf()
 
     def test_generate(self):
-        assert_generates_config(self._conf, '''
+        assert_generates_config(
+            self._conf,
+            '''
             [general]
 
             [xivo_device_tpl](!)
@@ -46,66 +60,81 @@ class TestSccpConf(unittest.TestCase):
             context = xivo-initconfig
             cid_name = Autoprov
             cid_num = autoprov
-        ''')
+        ''',
+        )
 
     def test_one_element_speeddials_section(self):
-        speedials = [{'exten': '1001',
-                      'fknum': 1,
-                      'label': 'user001',
-                      'supervision': 0,
-                      'user_id': 1229,
-                      'device': 'SEPACA016FDF235'}]
+        speedials = [
+            {
+                'exten': '1001',
+                'fknum': 1,
+                'label': 'user001',
+                'supervision': 0,
+                'user_id': 1229,
+                'device': 'SEPACA016FDF235',
+            }
+        ]
 
         sccp_conf = _SccpSpeedDialConf()
         sccp_conf.generate(speedials, self._output)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [1229-1]
             type = speeddial
             extension = 1001
             label = user001
             blf = 0
-        ''')
+        ''',
+        )
 
     def test_speeddial_no_label(self):
-        speedials = [{'exten': '1001',
-                      'fknum': 1,
-                      'label': None,
-                      'supervision': 0,
-                      'user_id': 1229,
-                      'device': 'SEPACA016FDF235'}]
+        speedials = [
+            {
+                'exten': '1001',
+                'fknum': 1,
+                'label': None,
+                'supervision': 0,
+                'user_id': 1229,
+                'device': 'SEPACA016FDF235',
+            }
+        ]
 
         sccp_conf = _SccpSpeedDialConf()
         sccp_conf.generate(speedials, self._output)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [1229-1]
             type = speeddial
             extension = 1001
             blf = 0
-        ''')
+        ''',
+        )
 
 
 class TestSccpGeneralConf(unittest.TestCase):
-
     def setUp(self):
         self._general_conf = _SccpGeneralSettingsConf()
         self._output = io.StringIO()
 
     def test_one_element_general_section(self):
-        items = [{'option_name': 'foo',
-                  'option_value': 'bar'}]
+        items = [{'option_name': 'foo', 'option_value': 'bar'}]
 
         self._general_conf.generate(items, self._output)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [general]
             foo = bar
-        ''')
+        ''',
+        )
 
 
 class TestSccpSplittedGeneralSettings(unittest.TestCase):
-
     def test_split_options(self):
         general_items = [
             {'option_name': 'foo'},
@@ -118,7 +147,9 @@ class TestSccpSplittedGeneralSettings(unittest.TestCase):
         ]
         items = list(itertools.chain(general_items, device_items, line_items))
 
-        splitted_settings = _SplittedGeneralSettings.new_from_dao_general_settings(items)
+        splitted_settings = _SplittedGeneralSettings.new_from_dao_general_settings(
+            items
+        )
 
         self.assertEqual(general_items, splitted_settings.general_items)
         self.assertEqual(device_items, splitted_settings.device_items)
@@ -126,7 +157,6 @@ class TestSccpSplittedGeneralSettings(unittest.TestCase):
 
 
 class TestSccpDeviceConf(unittest.TestCase):
-
     def setUp(self):
         self._device_conf = _SccpDeviceConf([])
         self._output = io.StringIO()
@@ -139,87 +169,118 @@ class TestSccpDeviceConf(unittest.TestCase):
 
         self._device_conf._generate_template(items, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [xivo_device_tpl](!)
             foo = bar
-        ''')
+        ''',
+        )
 
     def test_one_device_no_line_no_voicemail(self):
-        sccpdevice = [{'category': 'devices',
-                       'name': 'SEPACA016FDF235',
-                       'device': 'SEPACA016FDF235',
-                       'line': '',
-                       'voicemail': ''}]
+        sccpdevice = [
+            {
+                'category': 'devices',
+                'name': 'SEPACA016FDF235',
+                'device': 'SEPACA016FDF235',
+                'line': '',
+                'voicemail': '',
+            }
+        ]
 
         self._device_conf._generate_devices(sccpdevice, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [SEPACA016FDF235](xivo_device_tpl)
             type = device
-        ''')
+        ''',
+        )
 
     def test_one_element_devices_section(self):
-        sccpdevice = [{'category': 'devices',
-                       'name': 'SEPACA016FDF235',
-                       'device': 'SEPACA016FDF235',
-                       'line': '103',
-                       'voicemail': '103'}]
-
-        sccpspeeddials = [{'exten': '1001',
-                           'fknum': 1,
-                           'label': 'user001',
-                           'supervision': 0,
-                           'user_id': 1229,
-                           'device': 'SEPACA016FDF235'}]
-
-        device_conf = _SccpDeviceConf(sccpspeeddials)
-        device_conf._generate_devices(sccpdevice, self._ast_writer)
-
-        assert_config_equal(self._output.getvalue(), '''
-            [SEPACA016FDF235](xivo_device_tpl)
-            type = device
-            line = 103
-            voicemail = 103
-            speeddial = 1229-1
-        ''')
-
-    def test_multiple_speedials_devices_section(self):
-        sccpdevice = [{'category': 'devices',
-                       'name': 'SEPACA016FDF235',
-                       'device': 'SEPACA016FDF235',
-                       'line': '103',
-                       'voicemail': '103'}]
+        sccpdevice = [
+            {
+                'category': 'devices',
+                'name': 'SEPACA016FDF235',
+                'device': 'SEPACA016FDF235',
+                'line': '103',
+                'voicemail': '103',
+            }
+        ]
 
         sccpspeeddials = [
-            {'exten': '1002',
-             'fknum': 2,
-             'label': 'user002',
-             'supervision': 0,
-             'user_id': 1229,
-             'device': 'SEPACA016FDF235'},
-            {'exten': '1001',
-             'fknum': 1,
-             'label': 'user001',
-             'supervision': 0,
-             'user_id': 1229,
-             'device': 'SEPACA016FDF235'},
+            {
+                'exten': '1001',
+                'fknum': 1,
+                'label': 'user001',
+                'supervision': 0,
+                'user_id': 1229,
+                'device': 'SEPACA016FDF235',
+            }
         ]
 
         device_conf = _SccpDeviceConf(sccpspeeddials)
         device_conf._generate_devices(sccpdevice, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
+            [SEPACA016FDF235](xivo_device_tpl)
+            type = device
+            line = 103
+            voicemail = 103
+            speeddial = 1229-1
+        ''',
+        )
+
+    def test_multiple_speedials_devices_section(self):
+        sccpdevice = [
+            {
+                'category': 'devices',
+                'name': 'SEPACA016FDF235',
+                'device': 'SEPACA016FDF235',
+                'line': '103',
+                'voicemail': '103',
+            }
+        ]
+
+        sccpspeeddials = [
+            {
+                'exten': '1002',
+                'fknum': 2,
+                'label': 'user002',
+                'supervision': 0,
+                'user_id': 1229,
+                'device': 'SEPACA016FDF235',
+            },
+            {
+                'exten': '1001',
+                'fknum': 1,
+                'label': 'user001',
+                'supervision': 0,
+                'user_id': 1229,
+                'device': 'SEPACA016FDF235',
+            },
+        ]
+
+        device_conf = _SccpDeviceConf(sccpspeeddials)
+        device_conf._generate_devices(sccpdevice, self._ast_writer)
+
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [SEPACA016FDF235](xivo_device_tpl)
             type = device
             line = 103
             voicemail = 103
             speeddial = 1229-1
             speeddial = 1229-2
-        ''')
+        ''',
+        )
 
 
 class TestSccpLineConf(unittest.TestCase):
-
     def setUp(self):
         self._line_conf = _SccpLineConf()
         self._output = io.StringIO()
@@ -232,10 +293,13 @@ class TestSccpLineConf(unittest.TestCase):
 
         self._line_conf._generate_template(items, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [xivo_line_tpl](!)
             directmedia = 0
-        ''')
+        ''',
+        )
 
     def test_template_allow_option(self):
         items = [
@@ -244,11 +308,14 @@ class TestSccpLineConf(unittest.TestCase):
 
         self._line_conf._generate_template(items, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [xivo_line_tpl](!)
             disallow = all
             allow = ulaw
-        ''')
+        ''',
+        )
 
     def test_template_empty_allow_option(self):
         items = [
@@ -257,9 +324,12 @@ class TestSccpLineConf(unittest.TestCase):
 
         self._line_conf._generate_template(items, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [xivo_line_tpl](!)
-        ''')
+        ''',
+        )
 
     def test_template_disallow_option_is_ignored(self):
         items = [
@@ -268,30 +338,37 @@ class TestSccpLineConf(unittest.TestCase):
 
         self._line_conf._generate_template(items, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [xivo_line_tpl](!)
-        ''')
+        ''',
+        )
 
     def test_one_element_lines_section(self):
         uuid = str(uuid4())
-        sccpline = [{
-            'id': 13423,
-            'category': 'lines',
-            'name': '100',
-            'cid_name': 'jimmy',
-            'cid_num': '100',
-            'user_id': '1',
-            'uuid': uuid,
-            'language': 'fr_FR',
-            'number': '100',
-            'context': 'a_context',
-            'tenant_uuid': 'tenant-uuid',
-            'enable_online_recording': 1,
-        }]
+        sccpline = [
+            {
+                'id': 13423,
+                'category': 'lines',
+                'name': '100',
+                'cid_name': 'jimmy',
+                'cid_num': '100',
+                'user_id': '1',
+                'uuid': uuid,
+                'language': 'fr_FR',
+                'number': '100',
+                'context': 'a_context',
+                'tenant_uuid': 'tenant-uuid',
+                'enable_online_recording': 1,
+            }
+        ]
 
         self._line_conf._generate_lines(sccpline, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -307,28 +384,35 @@ class TestSccpLineConf(unittest.TestCase):
             setvar = DYNAMIC_FEATURES=togglerecord
             language = fr_FR
             context = a_context
-        '''.format(uuid=uuid))
+        '''.format(
+                uuid=uuid
+            ),
+        )
 
     def test_one_element_lines_section_no_language(self):
         uuid = str(uuid4())
-        sccpline = [{
-            'id': 13423,
-            'category': 'lines',
-            'name': '100',
-            'cid_name': 'jimmy',
-            'cid_num': '100',
-            'user_id': '1',
-            'uuid': uuid,
-            'language': None,
-            'number': '100',
-            'context': 'a_context',
-            'tenant_uuid': 'tenant-uuid',
-            'enable_online_recording': 0,
-        }]
+        sccpline = [
+            {
+                'id': 13423,
+                'category': 'lines',
+                'name': '100',
+                'cid_name': 'jimmy',
+                'cid_num': '100',
+                'user_id': '1',
+                'uuid': uuid,
+                'language': None,
+                'number': '100',
+                'context': 'a_context',
+                'tenant_uuid': 'tenant-uuid',
+                'enable_online_recording': 0,
+            }
+        ]
 
         self._line_conf._generate_lines(sccpline, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -342,29 +426,36 @@ class TestSccpLineConf(unittest.TestCase):
             setvar = WAZO_CHANNEL_DIRECTION=from-wazo
             setvar = WAZO_LINE_ID=13423
             context = a_context
-        '''.format(uuid=uuid))
+        '''.format(
+                uuid=uuid
+            ),
+        )
 
     def test_allow_no_disallow(self):
         uuid = str(uuid4())
-        sccpline = [{
-            'id': 13423,
-            'category': 'lines',
-            'name': '100',
-            'cid_name': 'jimmy',
-            'cid_num': '100',
-            'user_id': '1',
-            'language': None,
-            'number': '100',
-            'context': 'a_context',
-            'allow': 'g729,ulaw',
-            'uuid': uuid,
-            'tenant_uuid': 'tenant-uuid',
-            'enable_online_recording': 0,
-        }]
+        sccpline = [
+            {
+                'id': 13423,
+                'category': 'lines',
+                'name': '100',
+                'cid_name': 'jimmy',
+                'cid_num': '100',
+                'user_id': '1',
+                'language': None,
+                'number': '100',
+                'context': 'a_context',
+                'allow': 'g729,ulaw',
+                'uuid': uuid,
+                'tenant_uuid': 'tenant-uuid',
+                'enable_online_recording': 0,
+            }
+        ]
 
         self._line_conf._generate_lines(sccpline, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -379,30 +470,37 @@ class TestSccpLineConf(unittest.TestCase):
             setvar = WAZO_LINE_ID=13423
             context = a_context
             allow = g729,ulaw
-        '''.format(uuid=uuid))
+        '''.format(
+                uuid=uuid
+            ),
+        )
 
     def test_disallow_all_allow_order(self):
         uuid = str(uuid4())
-        sccpline = [{
-            'id': 13423,
-            'category': 'lines',
-            'name': '100',
-            'cid_name': 'jimmy',
-            'cid_num': '100',
-            'user_id': '1',
-            'uuid': uuid,
-            'language': None,
-            'number': '100',
-            'context': 'a_context',
-            'allow': 'g729,ulaw',
-            'disallow': 'all',
-            'tenant_uuid': 'tenant-uuid',
-            'enable_online_recording': 0,
-        }]
+        sccpline = [
+            {
+                'id': 13423,
+                'category': 'lines',
+                'name': '100',
+                'cid_name': 'jimmy',
+                'cid_num': '100',
+                'user_id': '1',
+                'uuid': uuid,
+                'language': None,
+                'number': '100',
+                'context': 'a_context',
+                'allow': 'g729,ulaw',
+                'disallow': 'all',
+                'tenant_uuid': 'tenant-uuid',
+                'enable_online_recording': 0,
+            }
+        ]
 
         self._line_conf._generate_lines(sccpline, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -418,30 +516,37 @@ class TestSccpLineConf(unittest.TestCase):
             context = a_context
             disallow = all
             allow = g729,ulaw
-        '''.format(uuid=uuid))
+        '''.format(
+                uuid=uuid
+            ),
+        )
 
     def test_call_and_pickup_groups(self):
         uuid = str(uuid4())
-        sccpline = [{
-            'id': 13423,
-            'category': 'lines',
-            'name': '100',
-            'cid_name': 'jimmy',
-            'cid_num': '100',
-            'user_id': '1',
-            'uuid': uuid,
-            'language': None,
-            'number': '100',
-            'context': 'a_context',
-            'callgroup': [1, 2, 3, 4],
-            'pickupgroup': [3, 4],
-            'tenant_uuid': 'tenant-uuid',
-            'enable_online_recording': 0,
-        }]
+        sccpline = [
+            {
+                'id': 13423,
+                'category': 'lines',
+                'name': '100',
+                'cid_name': 'jimmy',
+                'cid_num': '100',
+                'user_id': '1',
+                'uuid': uuid,
+                'language': None,
+                'number': '100',
+                'context': 'a_context',
+                'callgroup': [1, 2, 3, 4],
+                'pickupgroup': [3, 4],
+                'tenant_uuid': 'tenant-uuid',
+                'enable_online_recording': 0,
+            }
+        ]
 
         self._line_conf._generate_lines(sccpline, self._ast_writer)
 
-        assert_config_equal(self._output.getvalue(), '''
+        assert_config_equal(
+            self._output.getvalue(),
+            '''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -457,4 +562,7 @@ class TestSccpLineConf(unittest.TestCase):
             context = a_context
             namedcallgroup = 1,2,3,4
             namedpickupgroup = 3,4
-        '''.format(uuid=uuid))
+        '''.format(
+                uuid=uuid
+            ),
+        )

--- a/wazo_confgend/generators/tests/test_sccp.py
+++ b/wazo_confgend/generators/tests/test_sccp.py
@@ -367,7 +367,7 @@ class TestSccpLineConf(unittest.TestCase):
 
         assert_config_equal(
             self._output.getvalue(),
-            '''
+            f'''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -383,9 +383,7 @@ class TestSccpLineConf(unittest.TestCase):
             setvar = DYNAMIC_FEATURES=togglerecord
             language = fr_FR
             context = a_context
-        '''.format(
-                uuid=uuid
-            ),
+        ''',
         )
 
     def test_one_element_lines_section_no_language(self):
@@ -411,7 +409,7 @@ class TestSccpLineConf(unittest.TestCase):
 
         assert_config_equal(
             self._output.getvalue(),
-            '''
+            f'''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -425,9 +423,7 @@ class TestSccpLineConf(unittest.TestCase):
             setvar = WAZO_CHANNEL_DIRECTION=from-wazo
             setvar = WAZO_LINE_ID=13423
             context = a_context
-        '''.format(
-                uuid=uuid
-            ),
+        ''',
         )
 
     def test_allow_no_disallow(self):
@@ -454,7 +450,7 @@ class TestSccpLineConf(unittest.TestCase):
 
         assert_config_equal(
             self._output.getvalue(),
-            '''
+            f'''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -469,9 +465,7 @@ class TestSccpLineConf(unittest.TestCase):
             setvar = WAZO_LINE_ID=13423
             context = a_context
             allow = g729,ulaw
-        '''.format(
-                uuid=uuid
-            ),
+        ''',
         )
 
     def test_disallow_all_allow_order(self):
@@ -499,7 +493,7 @@ class TestSccpLineConf(unittest.TestCase):
 
         assert_config_equal(
             self._output.getvalue(),
-            '''
+            f'''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -515,9 +509,7 @@ class TestSccpLineConf(unittest.TestCase):
             context = a_context
             disallow = all
             allow = g729,ulaw
-        '''.format(
-                uuid=uuid
-            ),
+        ''',
         )
 
     def test_call_and_pickup_groups(self):
@@ -545,7 +537,7 @@ class TestSccpLineConf(unittest.TestCase):
 
         assert_config_equal(
             self._output.getvalue(),
-            '''
+            f'''
             [100](xivo_line_tpl)
             type = line
             cid_name = jimmy
@@ -561,7 +553,5 @@ class TestSccpLineConf(unittest.TestCase):
             context = a_context
             namedcallgroup = 1,2,3,4
             namedpickupgroup = 3,4
-        '''.format(
-                uuid=uuid
-            ),
+        ''',
         )

--- a/wazo_confgend/generators/tests/test_sccp.py
+++ b/wazo_confgend/generators/tests/test_sccp.py
@@ -2,10 +2,10 @@
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import itertools
-import StringIO
+import io
 import unittest
 
 from mock import Mock, patch
@@ -26,7 +26,7 @@ class TestSccpConf(unittest.TestCase):
     @patch('xivo_dao.asterisk_conf_dao.find_sccp_device_settings', Mock(return_value=[]))
     @patch('xivo_dao.asterisk_conf_dao.find_sccp_speeddial_settings', Mock(return_value=[]))
     def setUp(self):
-        self._output = StringIO.StringIO()
+        self._output = io.StringIO()
         self._conf = SccpConf()
 
     def test_generate(self):
@@ -90,7 +90,7 @@ class TestSccpGeneralConf(unittest.TestCase):
 
     def setUp(self):
         self._general_conf = _SccpGeneralSettingsConf()
-        self._output = StringIO.StringIO()
+        self._output = io.StringIO()
 
     def test_one_element_general_section(self):
         items = [{'option_name': 'foo',
@@ -129,7 +129,7 @@ class TestSccpDeviceConf(unittest.TestCase):
 
     def setUp(self):
         self._device_conf = _SccpDeviceConf([])
-        self._output = StringIO.StringIO()
+        self._output = io.StringIO()
         self._ast_writer = AsteriskFileWriter(self._output)
 
     def test_template_items(self):
@@ -222,7 +222,7 @@ class TestSccpLineConf(unittest.TestCase):
 
     def setUp(self):
         self._line_conf = _SccpLineConf()
-        self._output = StringIO.StringIO()
+        self._output = io.StringIO()
         self._ast_writer = AsteriskFileWriter(self._output)
 
     def test_template_directmedia_option(self):

--- a/wazo_confgend/generators/tests/test_util.py
+++ b/wazo_confgend/generators/tests/test_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/tests/test_util.py
+++ b/wazo_confgend/generators/tests/test_util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2015 Avencall
+# Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -10,7 +10,6 @@ from wazo_confgend.generators.util import AsteriskFileWriter
 
 
 class TestAsteriskFileWriter(unittest.TestCase):
-
     def setUp(self):
         self.output = io.StringIO()
         self.ast_file = AsteriskFileWriter(self.output)

--- a/wazo_confgend/generators/tests/test_util.py
+++ b/wazo_confgend/generators/tests/test_util.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
-import StringIO
+import io
 
 from hamcrest import assert_that, equal_to
 from wazo_confgend.generators.util import AsteriskFileWriter
@@ -12,7 +12,7 @@ from wazo_confgend.generators.util import AsteriskFileWriter
 class TestAsteriskFileWriter(unittest.TestCase):
 
     def setUp(self):
-        self.output = StringIO.StringIO()
+        self.output = io.StringIO()
         self.ast_file = AsteriskFileWriter(self.output)
 
     def test_write_section(self):

--- a/wazo_confgend/generators/tests/test_voicemail.py
+++ b/wazo_confgend/generators/tests/test_voicemail.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016 Proformatique Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 import textwrap

--- a/wazo_confgend/generators/tests/test_voicemail.py
+++ b/wazo_confgend/generators/tests/test_voicemail.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 import textwrap
 
@@ -18,7 +17,6 @@ from xivo_dao.alchemy.voicemail import Voicemail
 
 
 class TestVoicemailGenerator(unittest.TestCase):
-
     def test_given_no_voicemails_when_generating_then_generates_nothing(self):
         generator = VoicemailGenerator([])
 
@@ -26,85 +24,102 @@ class TestVoicemailGenerator(unittest.TestCase):
 
         assert_that(output, equal_to(''))
 
-    def test_given_voicemail_with_minimal_parameters_when_generating_then_generates_one_entry(self):
-        generator = VoicemailGenerator([
-            Voicemail(name='myvoicemail',
-                      number='1000',
-                      context='default',
-                      options=[]),
-        ])
+    def test_given_voicemail_with_minimal_parameters_when_generating_then_generates_one_entry(
+        self,
+    ):
+        generator = VoicemailGenerator(
+            [
+                Voicemail(
+                    name='myvoicemail', number='1000', context='default', options=[]
+                ),
+            ]
+        )
 
         expected = textwrap.dedent(
             """\
             [default]
             1000 => ,myvoicemail,,,deletevoicemail=no
 
-            """)
+            """
+        )
 
         output = generator.generate()
         assert_that(output, equal_to(expected))
 
-    def test_given_voicemail_with_all_parameters_when_generating_then_generates_one_entry(self):
-        generator = VoicemailGenerator([
-            Voicemail(name='myvoicemail',
-                      number='1000',
-                      context='default',
-                      password='1234',
-                      email='email@example.com',
-                      pager='pager@example.com',
-                      language='fr_FR',
-                      timezone='eu-fr',
-                      attach_audio=True,
-                      delete_messages=True,
-                      max_messages=5,
-                      ask_password=True,
-                      options=[
-                          ["volgain", "0.5"],
-                          ["saycid", "yes"]
-                      ]),
-        ])
+    def test_given_voicemail_with_all_parameters_when_generating_then_generates_one_entry(
+        self,
+    ):
+        generator = VoicemailGenerator(
+            [
+                Voicemail(
+                    name='myvoicemail',
+                    number='1000',
+                    context='default',
+                    password='1234',
+                    email='email@example.com',
+                    pager='pager@example.com',
+                    language='fr_FR',
+                    timezone='eu-fr',
+                    attach_audio=True,
+                    delete_messages=True,
+                    max_messages=5,
+                    ask_password=True,
+                    options=[["volgain", "0.5"], ["saycid", "yes"]],
+                ),
+            ]
+        )
 
         expected = textwrap.dedent(
             """\
             [default]
             1000 => 1234,myvoicemail,email@example.com,pager@example.com,language=fr_FR|tz=eu-fr|attach=yes|deletevoicemail=yes|maxmsg=5|volgain=0.5|saycid=yes
 
-            """)
+            """
+        )
 
         output = generator.generate()
         assert_that(output, equal_to(expected))
 
-    def test_given_voicemail_parameter_with_special_characters_when_generating_then_escapes_characters(self):
-        generator = VoicemailGenerator([
-            Voicemail(name='myvoicemail',
-                      number='1000',
-                      context='default',
-                      options=[
-                          ["emailbody", "howdy\thello\nworld\r|!"],
-                      ]),
-        ])
+    def test_given_voicemail_parameter_with_special_characters_when_generating_then_escapes_characters(
+        self,
+    ):
+        generator = VoicemailGenerator(
+            [
+                Voicemail(
+                    name='myvoicemail',
+                    number='1000',
+                    context='default',
+                    options=[
+                        ["emailbody", "howdy\thello\nworld\r|!"],
+                    ],
+                ),
+            ]
+        )
 
         expected = textwrap.dedent(
             """\
             [default]
             1000 => ,myvoicemail,,,deletevoicemail=no|emailbody=howdy\\thello\\nworld\\r!
 
-            """)
+            """
+        )
 
         output = generator.generate()
         assert_that(output, equal_to(expected))
 
-    def test_given_two_voicemails_in_same_context_when_generating_then_generates_two_entries(self):
-        generator = VoicemailGenerator([
-            Voicemail(name='myvoicemail',
-                      number='1000',
-                      context='default',
-                      options=[]),
-            Voicemail(name='othervoicemail',
-                      number='1001',
-                      context='default',
-                      options=[]),
-        ])
+    def test_given_two_voicemails_in_same_context_when_generating_then_generates_two_entries(
+        self,
+    ):
+        generator = VoicemailGenerator(
+            [
+                Voicemail(
+                    name='myvoicemail', number='1000', context='default', options=[]
+                ),
+                Voicemail(
+                    name='othervoicemail', number='1001', context='default', options=[]
+                ),
+            ]
+        )
 
         expected = textwrap.dedent(
             """\
@@ -112,22 +127,25 @@ class TestVoicemailGenerator(unittest.TestCase):
             1000 => ,myvoicemail,,,deletevoicemail=no
             1001 => ,othervoicemail,,,deletevoicemail=no
 
-            """)
+            """
+        )
 
         output = generator.generate()
         assert_that(output, equal_to(expected))
 
-    def test_given_two_voicemails_in_different_contexts_when_generating_then_generates_two_contexts(self):
-        generator = VoicemailGenerator([
-            Voicemail(name='myvoicemail',
-                      number='1000',
-                      context='default',
-                      options=[]),
-            Voicemail(name='othervoicemail',
-                      number='1001',
-                      context='otherctx',
-                      options=[]),
-        ])
+    def test_given_two_voicemails_in_different_contexts_when_generating_then_generates_two_contexts(
+        self,
+    ):
+        generator = VoicemailGenerator(
+            [
+                Voicemail(
+                    name='myvoicemail', number='1000', context='default', options=[]
+                ),
+                Voicemail(
+                    name='othervoicemail', number='1001', context='otherctx', options=[]
+                ),
+            ]
+        )
 
         expected = textwrap.dedent(
             """\
@@ -137,15 +155,18 @@ class TestVoicemailGenerator(unittest.TestCase):
             [otherctx]
             1001 => ,othervoicemail,,,deletevoicemail=no
 
-            """)
+            """
+        )
 
         output = generator.generate()
         assert_that(output, equal_to(expected))
 
 
 class TestVoicemailConf(unittest.TestCase):
-
-    @patch('xivo_dao.asterisk_conf_dao.find_voicemail_general_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_voicemail_general_settings',
+        Mock(return_value=[]),
+    )
     def setUp(self):
         self.voicemail_generator = Mock(VoicemailGenerator)
         self.voicemail_generator.generate.return_value = ''
@@ -154,62 +175,80 @@ class TestVoicemailConf(unittest.TestCase):
         self.voicemail_conf._voicemail_settings = []
 
     def test_empty_sections(self):
-        assert_generates_config(self.voicemail_conf, '''
+        assert_generates_config(
+            self.voicemail_conf,
+            '''
             [general]
 
             [zonemessages]
-        ''')
+        ''',
+        )
 
-    @patch('xivo_dao.asterisk_conf_dao.find_voicemail_general_settings', Mock(return_value=[]))
+    @patch(
+        'xivo_dao.asterisk_conf_dao.find_voicemail_general_settings',
+        Mock(return_value=[]),
+    )
     def test_non_ascii_voicemail(self):
         voicemail_generator = Mock(VoicemailGenerator)
         voicemail_generator.generate.return_value = '[defaulté]'
         voicemail_conf = VoicemailConf(voicemail_generator)
         voicemail_conf._voicemail_settings = []
 
-        assert_generates_config(voicemail_conf, '''
+        assert_generates_config(
+            voicemail_conf,
+            '''
             [general]
 
             [zonemessages]
 
             [defaulté]
-        ''')
+        ''',
+        )
 
     def test_one_element_general_section(self):
-        self.voicemail_conf._voicemail_settings = [{'category': 'general',
-                                                    'var_name': 'foo',
-                                                    'var_val': 'bar'}]
+        self.voicemail_conf._voicemail_settings = [
+            {'category': 'general', 'var_name': 'foo', 'var_val': 'bar'}
+        ]
 
-        assert_generates_config(self.voicemail_conf, '''
+        assert_generates_config(
+            self.voicemail_conf,
+            '''
             [general]
             foo = bar
 
             [zonemessages]
-        ''')
+        ''',
+        )
 
     def test_one_element_zonemessages_section(self):
-        self.voicemail_conf._voicemail_settings = [{'category': 'zonemessages',
-                                                    'var_name': 'foo',
-                                                    'var_val': 'bar'}]
+        self.voicemail_conf._voicemail_settings = [
+            {'category': 'zonemessages', 'var_name': 'foo', 'var_val': 'bar'}
+        ]
 
-        assert_generates_config(self.voicemail_conf, '''
+        assert_generates_config(
+            self.voicemail_conf,
+            '''
             [general]
 
             [zonemessages]
             foo = bar
-        ''')
+        ''',
+        )
 
     def test_escape_general_emailbody_option(self):
-        self.voicemail_conf._voicemail_settings = [{'category': 'general',
-                                                    'var_name': 'emailbody',
-                                                    'var_val': 'foo\nbar'}]
+        self.voicemail_conf._voicemail_settings = [
+            {'category': 'general', 'var_name': 'emailbody', 'var_val': 'foo\nbar'}
+        ]
 
-        assert_generates_config(self.voicemail_conf, '''
+        assert_generates_config(
+            self.voicemail_conf,
+            '''
             [general]
             emailbody = foo\\nbar
 
             [zonemessages]
-        ''')
+        ''',
+        )
 
     def test_voicemail_generation_included_in_config(self):
         self.voicemail_generator.generate.return_value = textwrap.dedent(
@@ -217,13 +256,17 @@ class TestVoicemailConf(unittest.TestCase):
             [default]
             1000 => ,myvoicemail,,,
 
-            """)
+            """
+        )
 
-        assert_generates_config(self.voicemail_conf, '''
+        assert_generates_config(
+            self.voicemail_conf,
+            '''
             [general]
 
             [zonemessages]
 
             [default]
             1000 => ,myvoicemail,,,
-        ''')
+        ''',
+        )

--- a/wazo_confgend/generators/tests/test_voicemail.py
+++ b/wazo_confgend/generators/tests/test_voicemail.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2012-2022 The Wazo Authors  (see the AUTHORS file)
 # Copyright (C) 2016 Proformatique Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_confgend/generators/tests/util.py
+++ b/wazo_confgend/generators/tests/util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/tests/util.py
+++ b/wazo_confgend/generators/tests/util.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2011-2016 Avencall
+# Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import io
@@ -45,9 +45,9 @@ def assert_lines_contain(config, expected):
 
 
 def _equal_to_section_name(expected):
-    return all_of(starts_with('['),
-                  ends_with(']'),
-                  equal_to_ignoring_whitespace(expected))
+    return all_of(
+        starts_with('['), ends_with(']'), equal_to_ignoring_whitespace(expected)
+    )
 
 
 def _section_body_matchers(expected):

--- a/wazo_confgend/generators/tests/util.py
+++ b/wazo_confgend/generators/tests/util.py
@@ -2,7 +2,7 @@
 # Copyright (C) 2011-2016 Avencall
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import StringIO
+import io
 
 from hamcrest import all_of
 from hamcrest import assert_that
@@ -15,7 +15,7 @@ from hamcrest import starts_with
 
 
 def assert_generates_config(generator, expected):
-    output = StringIO.StringIO()
+    output = io.StringIO()
     generator.generate(output)
 
     assert_config_equal(output.getvalue(), expected)

--- a/wazo_confgend/generators/util.py
+++ b/wazo_confgend/generators/util.py
@@ -33,7 +33,7 @@ def format_none_as_empty(value):
         return value
 
 
-class AsteriskFileWriter(object):
+class AsteriskFileWriter:
     def __init__(self, fobj):
         self._fobj = fobj
         self._first_section = True

--- a/wazo_confgend/generators/util.py
+++ b/wazo_confgend/generators/util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/util.py
+++ b/wazo_confgend/generators/util.py
@@ -3,8 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
-
 def format_ast_comment(comment):
     return '; {}'.format(comment)
 
@@ -37,7 +35,6 @@ def format_none_as_empty(value):
 
 
 class AsteriskFileWriter(object):
-
     def __init__(self, fobj):
         self._fobj = fobj
         self._first_section = True

--- a/wazo_confgend/generators/util.py
+++ b/wazo_confgend/generators/util.py
@@ -2,7 +2,7 @@
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 
 def format_ast_comment(comment):

--- a/wazo_confgend/generators/util.py
+++ b/wazo_confgend/generators/util.py
@@ -3,27 +3,27 @@
 
 
 def format_ast_comment(comment):
-    return '; {}'.format(comment)
+    return f'; {comment}'
 
 
 def format_ast_section(name):
-    return '[{}]'.format(name)
+    return f'[{name}]'
 
 
 def format_ast_section_tpl(name):
-    return '[{}](!)'.format(name)
+    return f'[{name}](!)'
 
 
 def format_ast_section_using_tpl(name, tpl_name):
-    return '[{}]({})'.format(name, tpl_name)
+    return f'[{name}]({tpl_name})'
 
 
 def format_ast_option(name, value):
-    return '{} = {}'.format(name, value).strip()
+    return f'{name} = {value}'.strip()
 
 
 def format_ast_object_option(name, value):
-    return '{} => {}'.format(name, value).strip()
+    return f'{name} => {value}'.strip()
 
 
 def format_none_as_empty(value):
@@ -72,4 +72,4 @@ class AsteriskFileWriter:
         self._fobj.write('\n')
 
     def _write_line(self, line):
-        self._fobj.write('{}\n'.format(line))
+        self._fobj.write(f'{line}\n')

--- a/wazo_confgend/generators/voicemail.py
+++ b/wazo_confgend/generators/voicemail.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/generators/voicemail.py
+++ b/wazo_confgend/generators/voicemail.py
@@ -2,7 +2,7 @@
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import itertools
 

--- a/wazo_confgend/generators/voicemail.py
+++ b/wazo_confgend/generators/voicemail.py
@@ -9,7 +9,7 @@ from xivo_dao import asterisk_conf_dao
 from xivo_dao.resources.voicemail import dao as voicemail_dao
 
 
-class VoicemailGenerator(object):
+class VoicemailGenerator:
     @classmethod
     def build(cls):
         return cls(voicemail_dao.find_all_by(enabled=True))
@@ -86,7 +86,7 @@ class VoicemailGenerator(object):
         )
 
 
-class VoicemailConf(object):
+class VoicemailConf:
     def __init__(self, voicemail_generator):
         self.voicemail_generator = voicemail_generator
         self._voicemail_settings = asterisk_conf_dao.find_voicemail_general_settings()

--- a/wazo_confgend/generators/voicemail.py
+++ b/wazo_confgend/generators/voicemail.py
@@ -30,7 +30,7 @@ class VoicemailGenerator:
         return itertools.groupby(self._voicemails, lambda v: v.context)
 
     def format_context(self, context):
-        return '[{}]'.format(context)
+        return f'[{context}]'
 
     def format_voicemails(self, voicemails):
         return '\n'.join(self.format_voicemail(v) for v in voicemails)
@@ -46,7 +46,7 @@ class VoicemailGenerator:
 
         line = ','.join(parts)
 
-        return '{} => {}'.format(voicemail.number, line)
+        return f'{voicemail.number} => {line}'
 
     def format_options(self, voicemail):
         options = []
@@ -66,9 +66,7 @@ class VoicemailGenerator:
 
         options += voicemail.options
 
-        options = (
-            '{}={}'.format(key, self.escape_string(value)) for key, value in options
-        )
+        options = (f'{key}={self.escape_string(value)}' for key, value in options)
 
         return '|'.join(options)
 
@@ -96,7 +94,7 @@ class VoicemailConf:
         self._gen_general_section(ast_writer)
         ast_writer.write_newline()
         self._gen_zonemessages_section(ast_writer)
-        output.write('\n{}\n'.format(self.voicemail_generator.generate()))
+        output.write(f'\n{self.voicemail_generator.generate()}\n')
 
     def _gen_general_section(self, ast_writer):
         ast_writer.write_section('general')

--- a/wazo_confgend/generators/voicemail.py
+++ b/wazo_confgend/generators/voicemail.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import itertools
 
 from wazo_confgend.generators.util import AsteriskFileWriter
@@ -12,7 +11,6 @@ from xivo_dao.resources.voicemail import dao as voicemail_dao
 
 
 class VoicemailGenerator(object):
-
     @classmethod
     def build(cls):
         return cls(voicemail_dao.find_all_by(enabled=True))
@@ -39,15 +37,17 @@ class VoicemailGenerator(object):
         return '\n'.join(self.format_voicemail(v) for v in voicemails)
 
     def format_voicemail(self, voicemail):
-        parts = (voicemail.password or '',
-                 voicemail.name or '',
-                 voicemail.email or '',
-                 voicemail.pager or '',
-                 self.format_options(voicemail))
+        parts = (
+            voicemail.password or '',
+            voicemail.name or '',
+            voicemail.email or '',
+            voicemail.pager or '',
+            self.format_options(voicemail),
+        )
 
         line = ','.join(parts)
 
-        return'{} => {}'.format(voicemail.number, line)
+        return '{} => {}'.format(voicemail.number, line)
 
     def format_options(self, voicemail):
         options = []
@@ -59,14 +59,17 @@ class VoicemailGenerator(object):
         if voicemail.attach_audio is not None:
             options.append(('attach', self.format_bool(voicemail.attach_audio)))
         if voicemail.delete_messages is not None:
-            options.append(('deletevoicemail', self.format_bool(voicemail.delete_messages)))
+            options.append(
+                ('deletevoicemail', self.format_bool(voicemail.delete_messages))
+            )
         if voicemail.max_messages is not None:
             options.append(('maxmsg', str(voicemail.max_messages))),
 
         options += voicemail.options
 
-        options = ('{}={}'.format(key, self.escape_string(value))
-                   for key, value in options)
+        options = (
+            '{}={}'.format(key, self.escape_string(value)) for key, value in options
+        )
 
         return '|'.join(options)
 
@@ -76,15 +79,15 @@ class VoicemailGenerator(object):
         return 'no'
 
     def escape_string(self, value):
-        return (value
-                .replace('\n', '\\n')
-                .replace('\r', '\\r')
-                .replace('\t', '\\t')
-                .replace('|', ''))
+        return (
+            value.replace('\n', '\\n')
+            .replace('\r', '\\r')
+            .replace('\t', '\\t')
+            .replace('|', '')
+        )
 
 
 class VoicemailConf(object):
-
     def __init__(self, voicemail_generator):
         self.voicemail_generator = voicemail_generator
         self._voicemail_settings = asterisk_conf_dao.find_voicemail_general_settings()

--- a/wazo_confgend/handler.py
+++ b/wazo_confgend/handler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/handler.py
+++ b/wazo_confgend/handler.py
@@ -13,11 +13,11 @@ class NoSuchHandler(Exception):
     pass
 
 
-class HandlerFactory(object):
+class HandlerFactory:
     pass
 
 
-class CachedHandlerFactoryDecorator(object):
+class CachedHandlerFactoryDecorator:
     def __init__(self, decorated_factory):
         self._factory = decorated_factory
         self._cache = {}
@@ -87,7 +87,7 @@ class FrontendHandlerFactory(HandlerFactory):
 
 
 class NullHandlerFactory(HandlerFactory):
-    class _NullHandler(object):
+    class _NullHandler:
         def __init__(self, resource, filename):
             self._error_msg = 'No handler found for {}/{}'.format(resource, filename)
 

--- a/wazo_confgend/handler.py
+++ b/wazo_confgend/handler.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import logging
 
 from stevedore import driver

--- a/wazo_confgend/handler.py
+++ b/wazo_confgend/handler.py
@@ -48,8 +48,8 @@ class PluginHandlerFactory(HandlerFactory):
         self._dependencies = dependencies
 
     def get(self, resource, filename):
-        suffix = '{}.{}'.format(resource, filename)
-        namespace = 'wazo_confgend.{}'.format(suffix)
+        suffix = f'{resource}.{filename}'
+        namespace = f'wazo_confgend.{suffix}'
         driver_name = self._config['plugins'].get(suffix)
         if not driver_name:
             raise NoSuchHandler()
@@ -89,7 +89,7 @@ class FrontendHandlerFactory(HandlerFactory):
 class NullHandlerFactory(HandlerFactory):
     class _NullHandler:
         def __init__(self, resource, filename):
-            self._error_msg = 'No handler found for {}/{}'.format(resource, filename)
+            self._error_msg = f'No handler found for {resource}/{filename}'
 
         def generate(self):
             logger.error(self._error_msg)

--- a/wazo_confgend/handler.py
+++ b/wazo_confgend/handler.py
@@ -2,7 +2,7 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import logging
 

--- a/wazo_confgend/helpers/asterisk.py
+++ b/wazo_confgend/helpers/asterisk.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/helpers/asterisk.py
+++ b/wazo_confgend/helpers/asterisk.py
@@ -8,7 +8,7 @@ from wazo_confgend.generators.util import AsteriskFileWriter
 logger = logging.getLogger(__name__)
 
 
-class AsteriskFileGenerator(object):
+class AsteriskFileGenerator:
     def __init__(self, dao):
         self.asterisk_file_dao = dao
 

--- a/wazo_confgend/helpers/asterisk.py
+++ b/wazo_confgend/helpers/asterisk.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
 
 
 import logging
@@ -11,7 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 class AsteriskFileGenerator(object):
-
     def __init__(self, dao):
         self.asterisk_file_dao = dao
 

--- a/wazo_confgend/helpers/asterisk.py
+++ b/wazo_confgend/helpers/asterisk.py
@@ -2,7 +2,7 @@
 # Copyright 2017-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import logging
 from wazo_confgend.generators.util import AsteriskFileWriter

--- a/wazo_confgend/helpers/asterisk.py
+++ b/wazo_confgend/helpers/asterisk.py
@@ -3,6 +3,11 @@
 
 
 import logging
+import configparser
+import collections
+import itertools
+
+
 from wazo_confgend.generators.util import AsteriskFileWriter
 
 logger = logging.getLogger(__name__)
@@ -44,3 +49,46 @@ class AsteriskFileGenerator:
             writer.write_section(required_section)
             writer._write_section_separator()
             sections.add(required_section)
+
+
+class CustomConfigParserStorage(collections.UserDict):
+    """configparser storage class customized for asterisk format parsing"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.data = collections.OrderedDict(self.data)
+        self.counter = itertools.count(start=1)
+
+    def __setitem__(self, k, v):
+        if isinstance(v, list):
+            # if list, we assume this is a new option declaration
+            # configparser creates option values as list to deal with multiline values
+            self.data[f"{next(self.counter)}:{k}"] = v
+        else:
+            # this is either a SectionProxy object,
+            # or an option value transformed from list form to string(so not a new option)
+            self.data[k] = v
+
+
+class AsteriskConfigParser(configparser.RawConfigParser):
+    def items(self, *args, **kwargs):
+        # Coupled with above CustomConfigParserStorage class as dict_type,
+        # we trick configparser into tracking each duplicate option declarations by storing them under different keys
+        # This reverts the trick in order to expose duplicate options under their real name
+        return [
+            (option.split(":", maxsplit=1)[-1], value)
+            for option, value in super().items(*args, **kwargs)
+        ]
+
+
+def asterisk_parser(food=None) -> AsteriskConfigParser:
+    parser = AsteriskConfigParser(
+        dict_type=CustomConfigParserStorage,
+        strict=False,
+        interpolation=None,
+        empty_lines_in_values=False,
+        inline_comment_prefixes=[";"],
+    )
+    if food:
+        parser.read_file(food)
+    return parser

--- a/wazo_confgend/helpers/tests/test_asterisk.py
+++ b/wazo_confgend/helpers/tests/test_asterisk.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/helpers/tests/test_asterisk.py
+++ b/wazo_confgend/helpers/tests/test_asterisk.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 
 from mock import Mock
@@ -15,7 +14,6 @@ from ..asterisk import AsteriskFileGenerator
 
 
 class TestConfBridgeConf(unittest.TestCase):
-
     def setUp(self):
         self.asterisk_file_dao = Mock()
         self.asterisk_file_generator = AsteriskFileGenerator(self.asterisk_file_dao)
@@ -25,30 +23,41 @@ class TestConfBridgeConf(unittest.TestCase):
         file_ = None
         self.asterisk_file_generator._generate_file(file_, self.output)
 
-        assert_config_equal(self.output.getvalue(), '''
-        ''')
+        assert_config_equal(
+            self.output.getvalue(),
+            '''
+        ''',
+        )
 
     def test_generate_file(self):
-        default_section = Mock(variables=[
-            Mock(key='type', value='user'),
-            Mock(key='max_members', value='50')
-        ])
+        default_section = Mock(
+            variables=[
+                Mock(key='type', value='user'),
+                Mock(key='max_members', value='50'),
+            ]
+        )
         default_section.name = 'default'
         general_section = Mock(variables=[])
         general_section.name = 'general'
-        bridge1_section = Mock(variables=[
-            Mock(key='record_conference', value='yes'),
-            Mock(key='toto', value=None)
-        ])
+        bridge1_section = Mock(
+            variables=[
+                Mock(key='record_conference', value='yes'),
+                Mock(key='toto', value=None),
+            ]
+        )
         bridge1_section.name = 'bridge-1'
-        file_ = Mock(sections_ordered=[
-            general_section,
-            default_section,
-            bridge1_section,
-        ])
+        file_ = Mock(
+            sections_ordered=[
+                general_section,
+                default_section,
+                bridge1_section,
+            ]
+        )
         self.asterisk_file_generator._generate_file(file_, self.output)
 
-        assert_config_equal(self.output.getvalue(), '''
+        assert_config_equal(
+            self.output.getvalue(),
+            '''
             [general]
 
             [default]
@@ -58,4 +67,5 @@ class TestConfBridgeConf(unittest.TestCase):
             [bridge-1]
             record_conference = yes
             toto =
-        ''')
+        ''',
+        )

--- a/wazo_confgend/helpers/tests/test_asterisk.py
+++ b/wazo_confgend/helpers/tests/test_asterisk.py
@@ -2,12 +2,12 @@
 # Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 
 from mock import Mock
-from StringIO import StringIO
+from io import StringIO
 
 from wazo_confgend.generators.tests.util import assert_config_equal
 

--- a/wazo_confgend/hints/adaptor.py
+++ b/wazo_confgend/hints/adaptor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/hints/adaptor.py
+++ b/wazo_confgend/hints/adaptor.py
@@ -25,7 +25,7 @@ class ProgfunckeyAdaptor(HintAdaptor):
         for hint in self.find_hints(context):
             arguments = self.progfunckey_arguments(hint)
             extension = fkey_extension(progfunckey, arguments)
-            yield (extension, 'Custom:{}'.format(extension))
+            yield (extension, f'Custom:{extension}')
 
 
 class UserAdaptor(HintAdaptor):
@@ -43,7 +43,7 @@ class UserSharedHintAdaptor(HintAdaptor):
 class ConferenceAdaptor(HintAdaptor):
     def generate(self, context):
         for hint in self.dao.conference_hints(context):
-            yield (hint.extension, 'confbridge:{}'.format(hint.conference_id))
+            yield (hint.extension, f'confbridge:{hint.conference_id}')
 
 
 class ForwardAdaptor(ProgfunckeyAdaptor):
@@ -82,7 +82,7 @@ class CustomAdaptor(HintAdaptor):
     def generate(self, context):
         for hint in self.dao.custom_hints(context):
             try:
-                yield (hint.extension, 'Custom:{}'.format(hint.extension))
+                yield (hint.extension, f'Custom:{hint.extension}')
             except UnicodeEncodeError:
                 logger.info('invalid custom function key "%s"', hint.extension)
                 continue
@@ -91,5 +91,5 @@ class CustomAdaptor(HintAdaptor):
 class BSFilterAdaptor(HintAdaptor):
     def generate(self, context):
         for hint in self.dao.bsfilter_hints(context):
-            extension = '{}{}'.format(hint.extension, hint.argument)
-            yield (extension, 'Custom:{}'.format(extension))
+            extension = f'{hint.extension}{hint.argument}'
+            yield (extension, f'Custom:{extension}')

--- a/wazo_confgend/hints/adaptor.py
+++ b/wazo_confgend/hints/adaptor.py
@@ -11,16 +11,16 @@ logger = logging.getLogger(__name__)
 
 
 class HintAdaptor(object):
-
     def __init__(self, dao):
         self.dao = dao
 
     def generate(self, context):
-        raise NotImplementedError("hint generation must be implemented in a child class")
+        raise NotImplementedError(
+            "hint generation must be implemented in a child class"
+        )
 
 
 class ProgfunckeyAdaptor(HintAdaptor):
-
     def generate(self, context):
         progfunckey = self.dao.progfunckey_extension()
         for hint in self.find_hints(context):
@@ -30,28 +30,24 @@ class ProgfunckeyAdaptor(HintAdaptor):
 
 
 class UserAdaptor(HintAdaptor):
-
     def generate(self, context):
         for hint in self.dao.user_hints(context):
             yield (hint.extension, hint.argument)
 
 
 class UserSharedHintAdaptor(HintAdaptor):
-
     def generate(self):
         for hint in self.dao.user_shared_hints():
             yield (hint.extension, hint.argument)
 
 
 class ConferenceAdaptor(HintAdaptor):
-
     def generate(self, context):
         for hint in self.dao.conference_hints(context):
             yield (hint.extension, 'confbridge:{}'.format(hint.conference_id))
 
 
 class ForwardAdaptor(ProgfunckeyAdaptor):
-
     def find_hints(self, context):
         return self.dao.forward_hints(context)
 
@@ -60,7 +56,6 @@ class ForwardAdaptor(ProgfunckeyAdaptor):
 
 
 class GroupMemberAdaptor(ProgfunckeyAdaptor):
-
     def find_hints(self, context):
         return self.dao.groupmember_hints(context)
 
@@ -69,7 +64,6 @@ class GroupMemberAdaptor(ProgfunckeyAdaptor):
 
 
 class ServiceAdaptor(ProgfunckeyAdaptor):
-
     def find_hints(self, context):
         return self.dao.service_hints(context)
 
@@ -78,7 +72,6 @@ class ServiceAdaptor(ProgfunckeyAdaptor):
 
 
 class AgentAdaptor(ProgfunckeyAdaptor):
-
     def find_hints(self, context):
         return self.dao.agent_hints(context)
 
@@ -87,7 +80,6 @@ class AgentAdaptor(ProgfunckeyAdaptor):
 
 
 class CustomAdaptor(HintAdaptor):
-
     def generate(self, context):
         for hint in self.dao.custom_hints(context):
             try:
@@ -98,7 +90,6 @@ class CustomAdaptor(HintAdaptor):
 
 
 class BSFilterAdaptor(HintAdaptor):
-
     def generate(self, context):
         for hint in self.dao.bsfilter_hints(context):
             extension = '{}{}'.format(hint.extension, hint.argument)

--- a/wazo_confgend/hints/adaptor.py
+++ b/wazo_confgend/hints/adaptor.py
@@ -9,7 +9,7 @@ from xivo.xivo_helpers import fkey_extension
 logger = logging.getLogger(__name__)
 
 
-class HintAdaptor(object):
+class HintAdaptor:
     def __init__(self, dao):
         self.dao = dao
 

--- a/wazo_confgend/hints/generator.py
+++ b/wazo_confgend/hints/generator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/hints/generator.py
+++ b/wazo_confgend/hints/generator.py
@@ -5,7 +5,7 @@ from wazo_confgend.hints import adaptor as hint_adaptor
 from xivo_dao.resources.func_key import hint_dao
 
 
-class HintGenerator(object):
+class HintGenerator:
 
     DIALPLAN = "exten = {extension},hint,{hint}"
 

--- a/wazo_confgend/hints/generator.py
+++ b/wazo_confgend/hints/generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2020 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from wazo_confgend.hints import adaptor as hint_adaptor
@@ -20,7 +20,7 @@ class HintGenerator(object):
             hint_adaptor.GroupMemberAdaptor(hint_dao),
             hint_adaptor.AgentAdaptor(hint_dao),
             hint_adaptor.BSFilterAdaptor(hint_dao),
-            hint_adaptor.CustomAdaptor(hint_dao)
+            hint_adaptor.CustomAdaptor(hint_dao),
         ]
         global_resource_adaptors = [
             hint_adaptor.UserSharedHintAdaptor(hint_dao),
@@ -45,6 +45,5 @@ class HintGenerator(object):
         for adaptor in self.context_resource_adaptors:
             for extension, hint in adaptor.generate(context):
                 if extension not in existing:
-                    yield self.DIALPLAN.format(extension=extension,
-                                               hint=hint)
+                    yield self.DIALPLAN.format(extension=extension, hint=hint)
                     existing.add(extension)

--- a/wazo_confgend/hints/tests/test_adaptor.py
+++ b/wazo_confgend/hints/tests/test_adaptor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/hints/tests/test_adaptor.py
+++ b/wazo_confgend/hints/tests/test_adaptor.py
@@ -30,7 +30,7 @@ class TestAdaptor(unittest.TestCase):
 
 class TestUserAdaptor(TestAdaptor):
     def setUp(self):
-        super(TestUserAdaptor, self).setUp()
+        super().setUp()
         self.dao = Mock()
         self.dao.user_hints.return_value = [
             Hint(user_id=42, extension='1000', argument='SIP/abcdef')
@@ -45,7 +45,7 @@ class TestUserAdaptor(TestAdaptor):
 
 class TestUserSharedHintsAdaptor(TestAdaptor):
     def setUp(self):
-        super(TestUserSharedHintsAdaptor, self).setUp()
+        super().setUp()
         self.dao = Mock()
         hints = [
             Hint(
@@ -89,7 +89,7 @@ class TestConferenceAdaptor(TestAdaptor):
 
 class TestForwardAdaptor(TestAdaptor):
     def setUp(self):
-        super(TestForwardAdaptor, self).setUp()
+        super().setUp()
         self.dao = Mock()
         self.dao.progfunckey_extension.return_value = '*735'
 

--- a/wazo_confgend/hints/tests/test_adaptor.py
+++ b/wazo_confgend/hints/tests/test_adaptor.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 
 from mock import Mock
@@ -31,13 +30,12 @@ class TestAdaptor(unittest.TestCase):
 
 
 class TestUserAdaptor(TestAdaptor):
-
     def setUp(self):
         super(TestUserAdaptor, self).setUp()
         self.dao = Mock()
-        self.dao.user_hints.return_value = [Hint(user_id=42,
-                                                 extension='1000',
-                                                 argument='SIP/abcdef')]
+        self.dao.user_hints.return_value = [
+            Hint(user_id=42, extension='1000', argument='SIP/abcdef')
+        ]
 
         self.adaptor = UserAdaptor(self.dao)
 
@@ -47,38 +45,50 @@ class TestUserAdaptor(TestAdaptor):
 
 
 class TestUserSharedHintsAdaptor(TestAdaptor):
-
     def setUp(self):
         super(TestUserSharedHintsAdaptor, self).setUp()
         self.dao = Mock()
         hints = [
-            Hint(extension='83f38716-27d8-45c5-8fa6-5c7cb18acb26', argument='PJSIP/abc&SCCP/1001'),
-            Hint(extension='0486beeb-4e3d-415b-b32d-660f44f6bab8', argument='PJSIP/def&SCCP/1002'),
+            Hint(
+                extension='83f38716-27d8-45c5-8fa6-5c7cb18acb26',
+                argument='PJSIP/abc&SCCP/1001',
+            ),
+            Hint(
+                extension='0486beeb-4e3d-415b-b32d-660f44f6bab8',
+                argument='PJSIP/def&SCCP/1002',
+            ),
         ]
         self.dao.user_shared_hints.return_value = hints
         self.adaptor = UserSharedHintAdaptor(self.dao)
 
     def test_adaptor_generate_shared_user_hints(self):
-        assert_that(self.adaptor.generate(), contains_inanyorder(
-            contains_exactly('83f38716-27d8-45c5-8fa6-5c7cb18acb26', 'PJSIP/abc&SCCP/1001'),
-            contains_exactly('0486beeb-4e3d-415b-b32d-660f44f6bab8', 'PJSIP/def&SCCP/1002'),
-        ))
+        assert_that(
+            self.adaptor.generate(),
+            contains_inanyorder(
+                contains_exactly(
+                    '83f38716-27d8-45c5-8fa6-5c7cb18acb26', 'PJSIP/abc&SCCP/1001'
+                ),
+                contains_exactly(
+                    '0486beeb-4e3d-415b-b32d-660f44f6bab8', 'PJSIP/def&SCCP/1002'
+                ),
+            ),
+        )
 
 
 class TestConferenceAdaptor(TestAdaptor):
-
     def test_adaptor_generates_conference_hint(self):
         dao = Mock()
         dao.conference_hints.return_value = [Hint(conference_id=1, extension='4000')]
 
         adaptor = ConferenceAdaptor(dao)
 
-        assert_that(adaptor.generate(CONTEXT), contains_exactly(('4000', 'confbridge:1')))
+        assert_that(
+            adaptor.generate(CONTEXT), contains_exactly(('4000', 'confbridge:1'))
+        )
         dao.conference_hints.assert_called_once_with(CONTEXT)
 
 
 class TestForwardAdaptor(TestAdaptor):
-
     def setUp(self):
         super(TestForwardAdaptor, self).setUp()
         self.dao = Mock()
@@ -87,67 +97,75 @@ class TestForwardAdaptor(TestAdaptor):
         self.adaptor = ForwardAdaptor(self.dao)
 
     def test_given_hint_with_argument_then_generates_progfunckey_with_argument(self):
-        self.dao.forward_hints.return_value = [Hint(user_id=42,
-                                               extension='*23',
-                                               argument='1234')]
+        self.dao.forward_hints.return_value = [
+            Hint(user_id=42, extension='*23', argument='1234')
+        ]
 
-        assert_that(self.adaptor.generate(CONTEXT),
-                    contains_exactly(('*73542***223*1234', 'Custom:*73542***223*1234')))
+        assert_that(
+            self.adaptor.generate(CONTEXT),
+            contains_exactly(('*73542***223*1234', 'Custom:*73542***223*1234')),
+        )
         self.dao.forward_hints.assert_called_once_with(CONTEXT)
 
-    def test_given_hint_without_argument_then_generates_progfunckey_without_argument(self):
-        self.dao.forward_hints.return_value = [Hint(user_id=42,
-                                               extension='*23',
-                                               argument=None)]
+    def test_given_hint_without_argument_then_generates_progfunckey_without_argument(
+        self,
+    ):
+        self.dao.forward_hints.return_value = [
+            Hint(user_id=42, extension='*23', argument=None)
+        ]
 
-        assert_that(self.adaptor.generate(CONTEXT),
-                    contains_exactly(('*73542***223', 'Custom:*73542***223')))
+        assert_that(
+            self.adaptor.generate(CONTEXT),
+            contains_exactly(('*73542***223', 'Custom:*73542***223')),
+        )
 
 
 class TestServiceAdaptor(TestAdaptor):
-
     def test_adaptor_generates_service_hint(self):
         dao = Mock()
         dao.progfunckey_extension.return_value = '*735'
-        dao.service_hints.return_value = [Hint(user_id=42,
-                                               extension='*26',
-                                               argument=None)]
+        dao.service_hints.return_value = [
+            Hint(user_id=42, extension='*26', argument=None)
+        ]
 
         adaptor = ServiceAdaptor(dao)
 
-        assert_that(adaptor.generate(CONTEXT),
-                    contains_exactly(('*73542***226', 'Custom:*73542***226')))
+        assert_that(
+            adaptor.generate(CONTEXT),
+            contains_exactly(('*73542***226', 'Custom:*73542***226')),
+        )
         dao.service_hints.assert_called_once_with(CONTEXT)
 
 
 class TestAgentAdaptor(TestAdaptor):
-
     def test_adaptor_generates_service_hint(self):
         dao = Mock()
         dao.progfunckey_extension.return_value = '*735'
-        dao.agent_hints.return_value = [Hint(user_id=42,
-                                             extension='*31',
-                                             argument='56')]
+        dao.agent_hints.return_value = [
+            Hint(user_id=42, extension='*31', argument='56')
+        ]
 
         adaptor = AgentAdaptor(dao)
 
-        assert_that(adaptor.generate(CONTEXT),
-                    contains_exactly(('*73542***231***356', 'Custom:*73542***231***356')))
+        assert_that(
+            adaptor.generate(CONTEXT),
+            contains_exactly(('*73542***231***356', 'Custom:*73542***231***356')),
+        )
         dao.agent_hints.assert_called_once_with(CONTEXT)
 
 
 class TestCustomAdaptor(TestAdaptor):
-
     def test_adaptor_generates_custom_hint(self):
         dao = Mock()
-        dao.custom_hints.return_value = [Hint(user_id=None,
-                                              extension='1234',
-                                              argument=None)]
+        dao.custom_hints.return_value = [
+            Hint(user_id=None, extension='1234', argument=None)
+        ]
 
         adaptor = CustomAdaptor(dao)
 
-        assert_that(adaptor.generate(CONTEXT),
-                    contains_exactly(('1234', 'Custom:1234')))
+        assert_that(
+            adaptor.generate(CONTEXT), contains_exactly(('1234', 'Custom:1234'))
+        )
         dao.custom_hints.assert_called_once_with(CONTEXT)
 
     def test_that_non_ascii_characters_are_ignored(self):
@@ -167,31 +185,32 @@ class TestCustomAdaptor(TestAdaptor):
 
 
 class TestBSFilterAdaptor(TestAdaptor):
-
     def test_adaptor_generates_bsfilter_hint(self):
         dao = Mock()
-        dao.bsfilter_hints.return_value = [Hint(user_id=42,
-                                                extension='*37',
-                                                argument='12')]
+        dao.bsfilter_hints.return_value = [
+            Hint(user_id=42, extension='*37', argument='12')
+        ]
 
         adaptor = BSFilterAdaptor(dao)
 
-        assert_that(adaptor.generate(CONTEXT),
-                    contains_exactly(('*3712', 'Custom:*3712')))
+        assert_that(
+            adaptor.generate(CONTEXT), contains_exactly(('*3712', 'Custom:*3712'))
+        )
         dao.bsfilter_hints.assert_called_once_with(CONTEXT)
 
 
 class TestGroupMemberAdaptor(TestAdaptor):
-
     def test_adaptor_generates_groupmember_hint(self):
         dao = Mock()
         dao.progfunckey_extension.return_value = '*735'
-        dao.groupmember_hints.return_value = [Hint(user_id=42,
-                                                   extension='*50',
-                                                   argument='18')]
+        dao.groupmember_hints.return_value = [
+            Hint(user_id=42, extension='*50', argument='18')
+        ]
 
         adaptor = GroupMemberAdaptor(dao)
 
-        assert_that(adaptor.generate(CONTEXT),
-                    contains_exactly(('*73542***250*18', 'Custom:*73542***250*18')))
+        assert_that(
+            adaptor.generate(CONTEXT),
+            contains_exactly(('*73542***250*18', 'Custom:*73542***250*18')),
+        )
         dao.groupmember_hints.assert_called_once_with(CONTEXT)

--- a/wazo_confgend/hints/tests/test_adaptor.py
+++ b/wazo_confgend/hints/tests/test_adaptor.py
@@ -2,7 +2,7 @@
 # Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 

--- a/wazo_confgend/hints/tests/test_generator.py
+++ b/wazo_confgend/hints/tests/test_generator.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/hints/tests/test_generator.py
+++ b/wazo_confgend/hints/tests/test_generator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2014-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -7,7 +7,7 @@ import unittest
 from mock import Mock, patch
 from hamcrest import assert_that, contains_exactly
 
-from ..import adaptor
+from .. import adaptor
 from ..generator import HintGenerator
 from ..adaptor import HintAdaptor
 
@@ -15,8 +15,9 @@ CONTEXT = 'context'
 
 
 class TestGenerator(unittest.TestCase):
-
-    def test_given_an_adaptor_that_generates_nothing_then_generator_returns_an_empty_list(self):
+    def test_given_an_adaptor_that_generates_nothing_then_generator_returns_an_empty_list(
+        self,
+    ):
         adaptor = Mock(HintAdaptor)
         adaptor.generate.return_value = []
 
@@ -24,13 +25,18 @@ class TestGenerator(unittest.TestCase):
 
         assert_that(generator.generate(CONTEXT), contains_exactly())
 
-    def test_given_an_adaptor_generates_a_hint_then_generator_returns_formatted_hint(self):
+    def test_given_an_adaptor_generates_a_hint_then_generator_returns_formatted_hint(
+        self,
+    ):
         adaptor = Mock(HintAdaptor)
         adaptor.generate.return_value = [('4000', 'confbridge:1')]
 
         generator = HintGenerator([adaptor], [])
 
-        assert_that(generator.generate(CONTEXT), contains_exactly('exten = 4000,hint,confbridge:1'))
+        assert_that(
+            generator.generate(CONTEXT),
+            contains_exactly('exten = 4000,hint,confbridge:1'),
+        )
         adaptor.generate.assert_called_once_with(CONTEXT)
 
     def test_given_2_adaptors_then_generates_hint_for_all_adaptors(self):
@@ -42,13 +48,18 @@ class TestGenerator(unittest.TestCase):
 
         generator = HintGenerator([first_adaptor, second_adaptor], [])
 
-        assert_that(generator.generate(CONTEXT),
-                    contains_exactly('exten = 1000,hint,1000',
-                                     'exten = 4000,hint,confbridge:1'))
+        assert_that(
+            generator.generate(CONTEXT),
+            contains_exactly(
+                'exten = 1000,hint,1000', 'exten = 4000,hint,confbridge:1'
+            ),
+        )
         first_adaptor.generate.assert_called_once_with(CONTEXT)
         second_adaptor.generate.assert_called_once_with(CONTEXT)
 
-    def test_given_2_adaptors_generate_same_hint_then_generator_returns_hint_only_once(self):
+    def test_given_2_adaptors_generate_same_hint_then_generator_returns_hint_only_once(
+        self,
+    ):
         first_adaptor = Mock(HintAdaptor)
         first_adaptor.generate.return_value = [('1000', 'PJSIP/abcdef')]
 
@@ -57,7 +68,10 @@ class TestGenerator(unittest.TestCase):
 
         generator = HintGenerator([first_adaptor, second_adaptor], [])
 
-        assert_that(generator.generate(CONTEXT), contains_exactly('exten = 1000,hint,PJSIP/abcdef'))
+        assert_that(
+            generator.generate(CONTEXT),
+            contains_exactly('exten = 1000,hint,PJSIP/abcdef'),
+        )
         first_adaptor.generate.assert_called_once_with(CONTEXT)
         second_adaptor.generate.assert_called_once_with(CONTEXT)
 
@@ -67,9 +81,12 @@ class TestGenerator(unittest.TestCase):
 
         generator = HintGenerator([], [first_adaptor])
 
-        assert_that(generator.generate_global_hints(), contains_exactly(
-            'exten = 1001,hint,PJSIP/abc&SCCP/1042',
-        ))
+        assert_that(
+            generator.generate_global_hints(),
+            contains_exactly(
+                'exten = 1001,hint,PJSIP/abc&SCCP/1042',
+            ),
+        )
 
     def test_that_user_generated_hints_are_not_overridden(self):
         custom_adaptor = Mock(adaptor.CustomAdaptor)

--- a/wazo_confgend/phoned.py
+++ b/wazo_confgend/phoned.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/phoned.py
+++ b/wazo_confgend/phoned.py
@@ -3,14 +3,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import yaml
 
 from xivo_dao import phone_access_dao
 
 
 class PhonedFrontend(object):
-
     def config_yml(self):
         authorized_subnets = phone_access_dao.get_authorized_subnets()
         generator = _ConfigGenerator(authorized_subnets)
@@ -19,13 +17,8 @@ class PhonedFrontend(object):
 
 
 class _ConfigGenerator(object):
-
     def __init__(self, authorized_subnets):
         self._authorized_subnets = authorized_subnets
 
     def generate(self):
-        return {
-            'rest_api': {
-                'authorized_subnets': self._authorized_subnets
-            }
-        }
+        return {'rest_api': {'authorized_subnets': self._authorized_subnets}}

--- a/wazo_confgend/phoned.py
+++ b/wazo_confgend/phoned.py
@@ -7,7 +7,7 @@ import yaml
 from xivo_dao import phone_access_dao
 
 
-class PhonedFrontend(object):
+class PhonedFrontend:
     def config_yml(self):
         authorized_subnets = phone_access_dao.get_authorized_subnets()
         generator = _ConfigGenerator(authorized_subnets)
@@ -15,7 +15,7 @@ class PhonedFrontend(object):
         return yaml.safe_dump(generator.generate())
 
 
-class _ConfigGenerator(object):
+class _ConfigGenerator:
     def __init__(self, authorized_subnets):
         self._authorized_subnets = authorized_subnets
 

--- a/wazo_confgend/phoned.py
+++ b/wazo_confgend/phoned.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import yaml
 

--- a/wazo_confgend/plugins/confbridge_conf.py
+++ b/wazo_confgend/plugins/confbridge_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/confbridge_conf.py
+++ b/wazo_confgend/plugins/confbridge_conf.py
@@ -10,7 +10,7 @@ from xivo_dao.resources.asterisk_file import dao as asterisk_file_dao
 from ..helpers.asterisk import AsteriskFileGenerator
 
 
-class ConfBridgeConfGenerator(object):
+class ConfBridgeConfGenerator:
     def __init__(self, dependencies):
         self.dependencies = dependencies
 
@@ -23,7 +23,7 @@ class ConfBridgeConfGenerator(object):
         return output.getvalue()
 
 
-class _ConfBridgeConf(object):
+class _ConfBridgeConf:
     def __init__(self, dao):
         self.conference_dao = dao
 

--- a/wazo_confgend/plugins/confbridge_conf.py
+++ b/wazo_confgend/plugins/confbridge_conf.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 from io import StringIO
 
 from xivo_dao.resources.conference import dao as conference_dao
@@ -13,7 +12,6 @@ from ..helpers.asterisk import AsteriskFileGenerator
 
 
 class ConfBridgeConfGenerator(object):
-
     def __init__(self, dependencies):
         self.dependencies = dependencies
 
@@ -27,7 +25,6 @@ class ConfBridgeConfGenerator(object):
 
 
 class _ConfBridgeConf(object):
-
     def __init__(self, dao):
         self.conference_dao = dao
 
@@ -72,9 +69,15 @@ class _ConfBridgeConf(object):
         yield '[xivo-user-profile-{}](wazo_default_user)'.format(row.id)
         yield 'type = user'
         yield 'quiet = {}'.format(self._convert_bool(row.quiet_join_leave))
-        yield 'announce_join_leave = {}'.format(self._convert_bool(row.announce_join_leave))
-        yield 'announce_user_count = {}'.format(self._convert_bool(row.announce_user_count))
-        yield 'announce_only_user = {}'.format(self._convert_bool(row.announce_only_user))
+        yield 'announce_join_leave = {}'.format(
+            self._convert_bool(row.announce_join_leave)
+        )
+        yield 'announce_user_count = {}'.format(
+            self._convert_bool(row.announce_user_count)
+        )
+        yield 'announce_only_user = {}'.format(
+            self._convert_bool(row.announce_only_user)
+        )
         if row.music_on_hold:
             yield 'music_on_hold_when_empty = yes'
             yield 'music_on_hold_class = {}'.format(row.music_on_hold)
@@ -97,14 +100,20 @@ class _ConfBridgeConf(object):
     def _gen_default_user_menu(self):
         yield '[xivo-default-user-menu]'
         yield 'type = menu'
-        yield '* = playback_and_continue({})'.format('&'.join(['dir-multi1',
-                                                               'digits/1&confbridge-mute-out',
-                                                               'digits/4&confbridge-dec-list-vol-out',
-                                                               'digits/5&confbridge-rest-list-vol-out',
-                                                               'digits/6&confbridge-inc-list-vol-out',
-                                                               'digits/7&confbridge-dec-talk-vol-out',
-                                                               'digits/8&confbridge-rest-talk-vol-out',
-                                                               'digits/9&confbridge-inc-talk-vol-out']))
+        yield '* = playback_and_continue({})'.format(
+            '&'.join(
+                [
+                    'dir-multi1',
+                    'digits/1&confbridge-mute-out',
+                    'digits/4&confbridge-dec-list-vol-out',
+                    'digits/5&confbridge-rest-list-vol-out',
+                    'digits/6&confbridge-inc-list-vol-out',
+                    'digits/7&confbridge-dec-talk-vol-out',
+                    'digits/8&confbridge-rest-talk-vol-out',
+                    'digits/9&confbridge-inc-talk-vol-out',
+                ]
+            )
+        )
         yield '1 = toggle_mute'
         yield '4 = decrease_listening_volume'
         yield '5 = reset_listening_volume'
@@ -115,16 +124,22 @@ class _ConfBridgeConf(object):
 
     def _gen_default_admin_menu(self):
         yield '[xivo-default-admin-menu](xivo-default-user-menu)'
-        yield '* = playback_and_continue({})'.format('&'.join(['dir-multi1',
-                                                               'digits/1&confbridge-mute-out',
-                                                               'digits/2&confbridge-lock-out',
-                                                               'digits/3&confbridge-remove-last-out',
-                                                               'digits/4&confbridge-dec-list-vol-out',
-                                                               'digits/5&confbridge-rest-list-vol-out',
-                                                               'digits/6&confbridge-inc-list-vol-out',
-                                                               'digits/7&confbridge-dec-talk-vol-out',
-                                                               'digits/8&confbridge-rest-talk-vol-out',
-                                                               'digits/9&confbridge-inc-talk-vol-out']))
+        yield '* = playback_and_continue({})'.format(
+            '&'.join(
+                [
+                    'dir-multi1',
+                    'digits/1&confbridge-mute-out',
+                    'digits/2&confbridge-lock-out',
+                    'digits/3&confbridge-remove-last-out',
+                    'digits/4&confbridge-dec-list-vol-out',
+                    'digits/5&confbridge-rest-list-vol-out',
+                    'digits/6&confbridge-inc-list-vol-out',
+                    'digits/7&confbridge-dec-talk-vol-out',
+                    'digits/8&confbridge-rest-talk-vol-out',
+                    'digits/9&confbridge-inc-talk-vol-out',
+                ]
+            )
+        )
         yield '2 = admin_toggle_conference_lock'
         yield '3 = admin_kick_last'
         yield '0 = admin_toggle_mute_participants'

--- a/wazo_confgend/plugins/confbridge_conf.py
+++ b/wazo_confgend/plugins/confbridge_conf.py
@@ -2,9 +2,9 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
 
-from StringIO import StringIO
+
+from io import StringIO
 
 from xivo_dao.resources.conference import dao as conference_dao
 from xivo_dao.resources.asterisk_file import dao as asterisk_file_dao

--- a/wazo_confgend/plugins/confbridge_conf.py
+++ b/wazo_confgend/plugins/confbridge_conf.py
@@ -44,45 +44,39 @@ class _ConfBridgeConf:
     def _gen_bridge_profile(self, conferences, output):
         for row in conferences:
             for line in self._format_bridge_profile(row):
-                output.write('{}\n'.format(line))
+                output.write(f'{line}\n')
             output.write('\n')
 
     def _gen_user_profile(self, conferences, output):
         for row in conferences:
             for line in self._format_user_profile(row):
-                output.write('{}\n'.format(line))
+                output.write(f'{line}\n')
             output.write('\n')
 
             if row.admin_pin:
                 for line in self._format_admin_profile(row):
-                    output.write('{}\n'.format(line))
+                    output.write(f'{line}\n')
             output.write('\n')
 
     def _format_bridge_profile(self, row):
-        yield '[xivo-bridge-profile-{}](wazo_default_bridge)'.format(row.id)
+        yield f'[xivo-bridge-profile-{row.id}](wazo_default_bridge)'
         yield 'type = bridge'
-        yield 'max_members = {}'.format(row.max_users)
-        yield 'record_conference = {}'.format(self._convert_bool(row.record))
+        yield f'max_members = {row.max_users}'
+        yield f'record_conference = {self._convert_bool(row.record)}'
 
     def _format_user_profile(self, row):
-        yield '[xivo-user-profile-{}](wazo_default_user)'.format(row.id)
+        yield f'[xivo-user-profile-{row.id}](wazo_default_user)'
         yield 'type = user'
-        yield 'quiet = {}'.format(self._convert_bool(row.quiet_join_leave))
-        yield 'announce_join_leave = {}'.format(
-            self._convert_bool(row.announce_join_leave)
-        )
-        yield 'announce_user_count = {}'.format(
-            self._convert_bool(row.announce_user_count)
-        )
-        yield 'announce_only_user = {}'.format(
-            self._convert_bool(row.announce_only_user)
-        )
+        yield f'quiet = {self._convert_bool(row.quiet_join_leave)}'
+        yield f'announce_join_leave = {self._convert_bool(row.announce_join_leave)}'
+        yield f'announce_user_count = {self._convert_bool(row.announce_user_count)}'
+        yield f'announce_only_user = {self._convert_bool(row.announce_only_user)}'
         if row.music_on_hold:
             yield 'music_on_hold_when_empty = yes'
-            yield 'music_on_hold_class = {}'.format(row.music_on_hold)
+            yield f'music_on_hold_class = {row.music_on_hold}'
 
     def _format_admin_profile(self, row):
-        yield '[xivo-admin-profile-{}](xivo-user-profile-{})'.format(row.id, row.id)
+        yield f'[xivo-admin-profile-{row.id}](xivo-user-profile-{row.id})'
         yield 'admin = yes'
 
     def _convert_bool(self, option):
@@ -90,11 +84,11 @@ class _ConfBridgeConf:
 
     def _gen_default_menu(self, output):
         for line in self._gen_default_user_menu():
-            output.write('{}\n'.format(line))
+            output.write(f'{line}\n')
 
         output.write('\n')
         for line in self._gen_default_admin_menu():
-            output.write('{}\n'.format(line))
+            output.write(f'{line}\n')
 
     def _gen_default_user_menu(self):
         yield '[xivo-default-user-menu]'
@@ -145,7 +139,7 @@ class _ConfBridgeConf:
 
     def _gen_meeting_config(self, output):
         for line in self._gen_default_meeting_config():
-            output.write('{}\n'.format(line))
+            output.write(f'{line}\n')
 
     def _gen_default_meeting_config(self):
         yield '[wazo-meeting-bridge-profile]'

--- a/wazo_confgend/plugins/features_conf.py
+++ b/wazo_confgend/plugins/features_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/features_conf.py
+++ b/wazo_confgend/plugins/features_conf.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 from wazo_confgend.generators.util import AsteriskFileWriter
 from xivo_dao import asterisk_conf_dao

--- a/wazo_confgend/plugins/features_conf.py
+++ b/wazo_confgend/plugins/features_conf.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 from wazo_confgend.generators.util import AsteriskFileWriter
 from xivo_dao import asterisk_conf_dao
 import logging

--- a/wazo_confgend/plugins/hep_conf.py
+++ b/wazo_confgend/plugins/hep_conf.py
@@ -2,9 +2,9 @@
 # Copyright 2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
 
-from StringIO import StringIO
+
+from io import StringIO
 
 from xivo_dao.resources.asterisk_file import dao as asterisk_file_dao
 

--- a/wazo_confgend/plugins/hep_conf.py
+++ b/wazo_confgend/plugins/hep_conf.py
@@ -9,7 +9,7 @@ from xivo_dao.resources.asterisk_file import dao as asterisk_file_dao
 from ..helpers.asterisk import AsteriskFileGenerator
 
 
-class HEPConfGenerator(object):
+class HEPConfGenerator:
     def __init__(self, dependencies):
         self.dependencies = dependencies
 

--- a/wazo_confgend/plugins/hep_conf.py
+++ b/wazo_confgend/plugins/hep_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/hep_conf.py
+++ b/wazo_confgend/plugins/hep_conf.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
 
 
 from io import StringIO
@@ -12,7 +11,6 @@ from ..helpers.asterisk import AsteriskFileGenerator
 
 
 class HEPConfGenerator(object):
-
     def __init__(self, dependencies):
         self.dependencies = dependencies
 

--- a/wazo_confgend/plugins/modules_conf.py
+++ b/wazo_confgend/plugins/modules_conf.py
@@ -2,7 +2,7 @@
 # Copyright 2019 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import logging
 
@@ -18,7 +18,7 @@ class ModulesConfGenerator(object):
 
         asterisk_modules = config.get('enabled_asterisk_modules', {})
         self.enabled_asterisk_modules = sorted(
-            [mod for mod, enabled in asterisk_modules.items() if not enabled]
+            [mod for mod, enabled in list(asterisk_modules.items()) if not enabled]
         )
 
         self.template_filename = config['templates']['modulesconf']

--- a/wazo_confgend/plugins/modules_conf.py
+++ b/wazo_confgend/plugins/modules_conf.py
@@ -9,7 +9,7 @@ from jinja2 import Template
 logger = logging.getLogger(__name__)
 
 
-class ModulesConfGenerator(object):
+class ModulesConfGenerator:
     def __init__(self, dependencies):
         config = dependencies['config']
 

--- a/wazo_confgend/plugins/modules_conf.py
+++ b/wazo_confgend/plugins/modules_conf.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
 
 
 import logging
@@ -12,7 +11,6 @@ logger = logging.getLogger(__name__)
 
 
 class ModulesConfGenerator(object):
-
     def __init__(self, dependencies):
         config = dependencies['config']
 

--- a/wazo_confgend/plugins/modules_conf.py
+++ b/wazo_confgend/plugins/modules_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/musiconhold_conf.py
+++ b/wazo_confgend/plugins/musiconhold_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/musiconhold_conf.py
+++ b/wazo_confgend/plugins/musiconhold_conf.py
@@ -2,7 +2,7 @@
 # Copyright 2017 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 from xivo_dao.resources.moh import dao as moh_dao
 

--- a/wazo_confgend/plugins/musiconhold_conf.py
+++ b/wazo_confgend/plugins/musiconhold_conf.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
 
 
 from xivo_dao.resources.moh import dao as moh_dao
 
 
 class MOHConfGenerator(object):
-
     def __init__(self, dependencies):
         self._tpl_helper = dependencies['tpl_helper']
 

--- a/wazo_confgend/plugins/musiconhold_conf.py
+++ b/wazo_confgend/plugins/musiconhold_conf.py
@@ -5,7 +5,7 @@
 from xivo_dao.resources.moh import dao as moh_dao
 
 
-class MOHConfGenerator(object):
+class MOHConfGenerator:
     def __init__(self, dependencies):
         self._tpl_helper = dependencies['tpl_helper']
 

--- a/wazo_confgend/plugins/pjsip_conf.py
+++ b/wazo_confgend/plugins/pjsip_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/pjsip_conf.py
+++ b/wazo_confgend/plugins/pjsip_conf.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-from __future__ import unicode_literals
 
-from StringIO import StringIO
+
+from io import StringIO
 
 from xivo_dao import asterisk_conf_dao
 from xivo_dao.resources.asterisk_file import dao as asterisk_file_dao

--- a/wazo_confgend/plugins/pjsip_conf.py
+++ b/wazo_confgend/plugins/pjsip_conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -14,14 +14,15 @@ from wazo_confgend.generators.util import AsteriskFileWriter
 
 
 class PJSIPConfGenerator(object):
-
     def __init__(self, dependencies):
         pass
 
     def generate(self):
         asterisk_file_generator = AsteriskFileGenerator(asterisk_file_dao)
         output = StringIO()
-        asterisk_file_generator.generate('pjsip.conf', output, required_sections=['global', 'system'])
+        asterisk_file_generator.generate(
+            'pjsip.conf', output, required_sections=['global', 'system']
+        )
         self.generate_transports(output)
         output.write('\n')
         self.generate_lines(output)
@@ -75,7 +76,9 @@ class PJSIPConfGenerator(object):
             name = endpoint['name']
             label = endpoint.get('label')
             endpoint_section_options = endpoint.get('endpoint_section_options', [])
-            registration_section_options = endpoint.get('registration_section_options', [])
+            registration_section_options = endpoint.get(
+                'registration_section_options', []
+            )
             writer.write_section(name, comment=label)
             writer.write_options(endpoint_section_options)
             sections = {

--- a/wazo_confgend/plugins/pjsip_conf.py
+++ b/wazo_confgend/plugins/pjsip_conf.py
@@ -12,7 +12,7 @@ from ..helpers.asterisk import AsteriskFileGenerator
 from wazo_confgend.generators.util import AsteriskFileWriter
 
 
-class PJSIPConfGenerator(object):
+class PJSIPConfGenerator:
     def __init__(self, dependencies):
         pass
 

--- a/wazo_confgend/plugins/provd_conf.py
+++ b/wazo_confgend/plugins/provd_conf.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import yaml
 
 from xivo_dao import init_db_from_config
@@ -13,7 +12,6 @@ from xivo_dao.alchemy.netiface import Netiface
 
 
 class ProvdNetworkConfGenerator(object):
-
     def __init__(self, dependencies):
         init_db_from_config(dependencies['config'])
 
@@ -24,7 +22,11 @@ class ProvdNetworkConfGenerator(object):
         return result.net4_ip
 
     def get_netiface_net4_ip(self, session):
-        result = session.query(Netiface.address).filter(Netiface.networktype == 'voip').first()
+        result = (
+            session.query(Netiface.address)
+            .filter(Netiface.networktype == 'voip')
+            .first()
+        )
         if not result:
             return
         return result.address
@@ -38,7 +40,9 @@ class ProvdNetworkConfGenerator(object):
     def generate(self):
         with session_scope(read_only=True) as session:
             config = {}
-            external_ip = self.get_provd_net4_ip(session) or self.get_netiface_net4_ip(session)
+            external_ip = self.get_provd_net4_ip(session) or self.get_netiface_net4_ip(
+                session
+            )
             external_port = self.get_provd_http_port(session)
 
             sections = {

--- a/wazo_confgend/plugins/provd_conf.py
+++ b/wazo_confgend/plugins/provd_conf.py
@@ -10,7 +10,7 @@ from xivo_dao.alchemy.provisioning import Provisioning
 from xivo_dao.alchemy.netiface import Netiface
 
 
-class ProvdNetworkConfGenerator(object):
+class ProvdNetworkConfGenerator:
     def __init__(self, dependencies):
         init_db_from_config(dependencies['config'])
 

--- a/wazo_confgend/plugins/provd_conf.py
+++ b/wazo_confgend/plugins/provd_conf.py
@@ -2,7 +2,7 @@
 # Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import yaml
 
@@ -48,8 +48,8 @@ class ProvdNetworkConfGenerator(object):
                 }
             }
 
-            for section_name, section_value in sections.iteritems():
-                for option, value in section_value.iteritems():
+            for section_name, section_value in sections.items():
+                for option, value in section_value.items():
                     if value:
                         if section_name not in config:
                             config.update({section_name: {}})

--- a/wazo_confgend/plugins/provd_conf.py
+++ b/wazo_confgend/plugins/provd_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/rtp_conf.py
+++ b/wazo_confgend/plugins/rtp_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/rtp_conf.py
+++ b/wazo_confgend/plugins/rtp_conf.py
@@ -2,9 +2,9 @@
 # Copyright 2018 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
 
-from StringIO import StringIO
+
+from io import StringIO
 
 from xivo_dao.resources.asterisk_file import dao as asterisk_file_dao
 

--- a/wazo_confgend/plugins/rtp_conf.py
+++ b/wazo_confgend/plugins/rtp_conf.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
-
 
 
 from io import StringIO
@@ -12,7 +11,6 @@ from ..helpers.asterisk import AsteriskFileGenerator
 
 
 class RTPConfGenerator(object):
-
     def __init__(self, dependencies):
         self.dependencies = dependencies
 

--- a/wazo_confgend/plugins/rtp_conf.py
+++ b/wazo_confgend/plugins/rtp_conf.py
@@ -9,7 +9,7 @@ from xivo_dao.resources.asterisk_file import dao as asterisk_file_dao
 from ..helpers.asterisk import AsteriskFileGenerator
 
 
-class RTPConfGenerator(object):
+class RTPConfGenerator:
     def __init__(self, dependencies):
         self.dependencies = dependencies
 

--- a/wazo_confgend/plugins/tests/test_confbridge.py
+++ b/wazo_confgend/plugins/tests/test_confbridge.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/tests/test_confbridge.py
+++ b/wazo_confgend/plugins/tests/test_confbridge.py
@@ -5,7 +5,7 @@
 import unittest
 
 from mock import Mock
-from StringIO import StringIO
+from io import StringIO
 
 from xivo_dao.alchemy.conference import Conference
 from wazo_confgend.generators.tests.util import assert_config_equal

--- a/wazo_confgend/plugins/tests/test_confbridge.py
+++ b/wazo_confgend/plugins/tests/test_confbridge.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2016-2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -14,7 +14,6 @@ from ..confbridge_conf import _ConfBridgeConf
 
 
 class TestConfBridgeConf(unittest.TestCase):
-
     def setUp(self):
         self.conference_dao = Mock()
         self.conference_dao.find_all_by.return_value = []
@@ -28,7 +27,9 @@ class TestConfBridgeConf(unittest.TestCase):
         ]
         self.confbridge_conf._gen_bridge_profile(conferences, self.output)
 
-        assert_config_equal(self.output.getvalue(), '''
+        assert_config_equal(
+            self.output.getvalue(),
+            '''
             [xivo-bridge-profile-1](wazo_default_bridge)
             type = bridge
             max_members = 50
@@ -38,28 +39,35 @@ class TestConfBridgeConf(unittest.TestCase):
             type = bridge
             max_members = 0
             record_conference = no
-        ''')
+        ''',
+        )
 
     def test_gen_user_profile(self):
         conferences = [
-            Conference(id=1,
-                       admin_pin=None,
-                       music_on_hold=None,
-                       quiet_join_leave=False,
-                       announce_join_leave=False,
-                       announce_user_count=False,
-                       announce_only_user=False),
-            Conference(id=2,
-                       admin_pin='1234',
-                       music_on_hold='Music',
-                       quiet_join_leave=True,
-                       announce_join_leave=True,
-                       announce_user_count=True,
-                       announce_only_user=True),
+            Conference(
+                id=1,
+                admin_pin=None,
+                music_on_hold=None,
+                quiet_join_leave=False,
+                announce_join_leave=False,
+                announce_user_count=False,
+                announce_only_user=False,
+            ),
+            Conference(
+                id=2,
+                admin_pin='1234',
+                music_on_hold='Music',
+                quiet_join_leave=True,
+                announce_join_leave=True,
+                announce_user_count=True,
+                announce_only_user=True,
+            ),
         ]
         self.confbridge_conf._gen_user_profile(conferences, self.output)
 
-        assert_config_equal(self.output.getvalue(), '''
+        assert_config_equal(
+            self.output.getvalue(),
+            '''
             [xivo-user-profile-1](wazo_default_user)
             type = user
             quiet = no
@@ -78,12 +86,15 @@ class TestConfBridgeConf(unittest.TestCase):
 
             [xivo-admin-profile-2](xivo-user-profile-2)
             admin = yes
-        ''')
+        ''',
+        )
 
     def test_gen_default_menu(self):
         self.confbridge_conf._gen_default_menu(self.output)
 
-        assert_config_equal(self.output.getvalue(), '''
+        assert_config_equal(
+            self.output.getvalue(),
+            '''
         [xivo-default-user-menu]
         type = menu
         * = playback_and_continue(dir-multi1&digits/1&confbridge-mute-out&digits/4&confbridge-dec-list-vol-out&digits/5&confbridge-rest-list-vol-out&digits/6&confbridge-inc-list-vol-out&digits/7&confbridge-dec-talk-vol-out&digits/8&confbridge-rest-talk-vol-out&digits/9&confbridge-inc-talk-vol-out)
@@ -100,4 +111,5 @@ class TestConfBridgeConf(unittest.TestCase):
         2 = admin_toggle_conference_lock
         3 = admin_kick_last
         0 = admin_toggle_mute_participants
-        ''')
+        ''',
+        )

--- a/wazo_confgend/plugins/tests/test_features_conf.py
+++ b/wazo_confgend/plugins/tests/test_features_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/tests/test_features_conf.py
+++ b/wazo_confgend/plugins/tests/test_features_conf.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 
 from mock import patch
@@ -13,9 +12,7 @@ from wazo_confgend.generators.tests.util import assert_config_equal
 
 class TestFeaturesConf(unittest.TestCase):
     def setUp(self):
-        self.dependencies = {
-
-        }
+        self.dependencies = {}
 
     def _new_conf(self, settings):
         with patch('xivo_dao.asterisk_conf_dao.find_features_settings'):
@@ -33,13 +30,16 @@ class TestFeaturesConf(unittest.TestCase):
         features_conf_gen = self._new_conf(settings)
         features_conf = features_conf_gen.generate()
 
-        assert_config_equal(features_conf, '''
+        assert_config_equal(
+            features_conf,
+            '''
             [general]
 
             [featuremap]
 
             [applicationmap]
-        ''')
+        ''',
+        )
 
     def test_settings(self):
         settings = {
@@ -52,7 +52,9 @@ class TestFeaturesConf(unittest.TestCase):
 
         features_conf = features_conf_gen.generate()
 
-        assert_config_equal(features_conf, '''
+        assert_config_equal(
+            features_conf,
+            '''
             [general]
             pickupexten = *8
 
@@ -61,4 +63,5 @@ class TestFeaturesConf(unittest.TestCase):
 
             [applicationmap]
             toto = *1
-        ''')
+        ''',
+        )

--- a/wazo_confgend/plugins/tests/test_features_conf.py
+++ b/wazo_confgend/plugins/tests/test_features_conf.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 

--- a/wazo_confgend/plugins/tests/test_modules_conf.py
+++ b/wazo_confgend/plugins/tests/test_modules_conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -18,9 +18,10 @@ TEMPLATE = b'''\
 
 
 class TestModulesConfGenerator(unittest.TestCase):
-
     def setUp(self):
-        with tempfile.NamedTemporaryFile(suffix='.conf.jinja2', mode='wb', delete=False) as f:
+        with tempfile.NamedTemporaryFile(
+            suffix='.conf.jinja2', mode='wb', delete=False
+        ) as f:
             self.template_filename = f.name
             f.write(TEMPLATE)
 
@@ -31,7 +32,7 @@ class TestModulesConfGenerator(unittest.TestCase):
                     'chan_sip.so': False,
                     'chan_dahdi.so': True,
                     'chan_skinny.so': False,
-                }
+                },
             }
         }
         self.generator = ModulesConfGenerator(dependencies)
@@ -42,7 +43,10 @@ class TestModulesConfGenerator(unittest.TestCase):
     def test_generate(self):
         result = self.generator.generate()
 
-        assert_config_equal(result, '''
+        assert_config_equal(
+            result,
+            '''
             chan_sip.so
             chan_skinny.so
-        ''')
+        ''',
+        )

--- a/wazo_confgend/plugins/tests/test_modules_conf.py
+++ b/wazo_confgend/plugins/tests/test_modules_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/tests/test_musiconhold.py
+++ b/wazo_confgend/plugins/tests/test_musiconhold.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/tests/test_musiconhold.py
+++ b/wazo_confgend/plugins/tests/test_musiconhold.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -14,7 +14,6 @@ from ..musiconhold_conf import MOHConfGenerator
 
 
 class TestConfBridgeConf(unittest.TestCase):
-
     def setUp(self):
         self.moh_dao = Mock()
         loader = PackageLoader('wazo_confgend.template', 'templates')
@@ -31,12 +30,15 @@ class TestConfBridgeConf(unittest.TestCase):
 
         value = self.generator.generate()
 
-        assert_config_equal(value, '''
+        assert_config_equal(
+            value,
+            '''
             [foo]
             mode = files
             directory = /var/lib/asterisk/moh/foo
             sort = alpha
-        ''')
+        ''',
+        )
 
     @patch('wazo_confgend.plugins.musiconhold_conf.moh_dao')
     def test_generate_mode_custom(self, mock_moh_dao):
@@ -47,11 +49,14 @@ class TestConfBridgeConf(unittest.TestCase):
 
         value = self.generator.generate()
 
-        assert_config_equal(value, '''
+        assert_config_equal(
+            value,
+            '''
             [bar]
             mode = custom
             application = /bin/false rrr
-        ''')
+        ''',
+        )
 
     @patch('wazo_confgend.plugins.musiconhold_conf.moh_dao')
     def test_generate_unknown_sort(self, mock_moh_dao):
@@ -62,9 +67,12 @@ class TestConfBridgeConf(unittest.TestCase):
 
         value = self.generator.generate()
 
-        assert_config_equal(value, '''
+        assert_config_equal(
+            value,
+            '''
             [foo]
             mode = files
             directory = /var/lib/asterisk/moh/foo
             sort = rabbit
-        ''')
+        ''',
+        )

--- a/wazo_confgend/plugins/tests/test_pjsip_conf.py
+++ b/wazo_confgend/plugins/tests/test_pjsip_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/plugins/tests/test_pjsip_conf.py
+++ b/wazo_confgend/plugins/tests/test_pjsip_conf.py
@@ -257,7 +257,7 @@ class TestPJSIPConfGenerator(unittest.TestCase):
                         ['aors', name_1],
                         ['auth', name_1],
                         ['allow', '!all,ulaw'],
-                        ['outbound_auth', 'outbound_auth_{}'.format(name_1)],
+                        ['outbound_auth', f'outbound_auth_{name_1}'],
                     ],
                     'identify_section_options': [
                         ['type', 'identify'],

--- a/wazo_confgend/plugins/tests/test_pjsip_conf.py
+++ b/wazo_confgend/plugins/tests/test_pjsip_conf.py
@@ -17,29 +17,31 @@ SearchResult = namedtuple('SearchResult', ['total', 'items'])
 
 
 class TestPJSIPConfGenerator(unittest.TestCase):
-
     def setUp(self):
         self.generator = PJSIPConfGenerator(dependencies=None)
 
     def test_generate_transports(self):
         output = StringIO()
         with patch('wazo_confgend.plugins.pjsip_conf.transport_dao') as dao:
-            dao.search.return_value = SearchResult(2, [
-                PJSIPTransport(
-                    name='transport-udp',
-                    options=[
-                        ['protocol', 'udp'],
-                        ['bind', '0.0.0.0:5060'],
-                    ]
-                ),
-                PJSIPTransport(
-                    name='transport-wss',
-                    options=[
-                        ['protocol', 'wss'],
-                        ['bind', '0.0.0.0:5060'],
-                    ]
-                ),
-            ])
+            dao.search.return_value = SearchResult(
+                2,
+                [
+                    PJSIPTransport(
+                        name='transport-udp',
+                        options=[
+                            ['protocol', 'udp'],
+                            ['bind', '0.0.0.0:5060'],
+                        ],
+                    ),
+                    PJSIPTransport(
+                        name='transport-wss',
+                        options=[
+                            ['protocol', 'wss'],
+                            ['bind', '0.0.0.0:5060'],
+                        ],
+                    ),
+                ],
+            )
 
             self.generator.generate_transports(output)
             assert_config_equal(
@@ -54,7 +56,7 @@ class TestPJSIPConfGenerator(unittest.TestCase):
                 type = transport
                 protocol = wss
                 bind = 0.0.0.0:5060
-                '''
+                ''',
             )
 
     def test_generate_users(self):
@@ -142,7 +144,7 @@ class TestPJSIPConfGenerator(unittest.TestCase):
                     label_2=label_2,
                     name_1=name_1,
                     name_2=name_2,
-                )
+                ),
             )
 
     def test_generate_meeting_guests(self):
@@ -231,7 +233,7 @@ class TestPJSIPConfGenerator(unittest.TestCase):
                     label_2=label_2,
                     name_1=name_1,
                     name_2=name_2,
-                )
+                ),
             )
 
     def test_generate_trunks(self):
@@ -267,7 +269,10 @@ class TestPJSIPConfGenerator(unittest.TestCase):
                     'registration_section_options': [
                         ['type', 'registration'],
                         ['expiration', '120'],
-                        ['outbound_auth', 'auth_reg_dev_370@wazo-dev-gateway.lan.wazo.io'],
+                        [
+                            'outbound_auth',
+                            'auth_reg_dev_370@wazo-dev-gateway.lan.wazo.io',
+                        ],
                     ],
                     'registration_outbound_auth_section_options': [
                         ['type', 'auth'],
@@ -323,5 +328,7 @@ class TestPJSIPConfGenerator(unittest.TestCase):
                 type = registration
                 expiration = 120
                 outbound_auth = auth_reg_dev_370@wazo-dev-gateway.lan.wazo.io
-                '''.format(label_1=label_1, name_1=name_1)
+                '''.format(
+                    label_1=label_1, name_1=name_1
+                ),
             )

--- a/wazo_confgend/plugins/tests/test_pjsip_conf.py
+++ b/wazo_confgend/plugins/tests/test_pjsip_conf.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 from mock import patch
 
-from StringIO import StringIO
+from io import StringIO
 from xivo_dao.alchemy.pjsip_transport import PJSIPTransport
 from wazo_confgend.generators.tests.util import assert_config_equal
 

--- a/wazo_confgend/plugins/tests/test_pjsip_conf.py
+++ b/wazo_confgend/plugins/tests/test_pjsip_conf.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import unittest
@@ -147,9 +147,9 @@ class TestPJSIPConfGenerator(unittest.TestCase):
 
     def test_generate_meeting_guests(self):
         output = StringIO()
-        name_1 = 'abcdef'
+        name_1 = 'abcdeféèìïöçàäỳÿüùúóíá'
         label_1 = 'meeting_guest_1_uuid'
-        name_2 = 'ghijkl'
+        name_2 = 'ghijkléèìïöçàäỳÿüùúóíá'
         label_2 = 'meeting_guest_2_uuid'
 
         with patch('wazo_confgend.plugins.pjsip_conf.asterisk_conf_dao') as dao:

--- a/wazo_confgend/plugins/tests/test_provd_conf.py
+++ b/wazo_confgend/plugins/tests/test_provd_conf.py
@@ -12,7 +12,6 @@ from ..provd_conf import ProvdNetworkConfGenerator
 
 
 class TestProvdNetworkConf(unittest.TestCase):
-
     def setUp(self):
         dependencies = {'config': {}}
         self.generator = ProvdNetworkConfGenerator(dependencies)
@@ -22,67 +21,98 @@ class TestProvdNetworkConf(unittest.TestCase):
         session_scope.__enter__ = Mock(return_value=Mock())
         session_scope.__exit__ = Mock(return_value=None)
 
-        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip,\
-                patch.object(self.generator, 'get_provd_http_port') as provd_http_port,\
-                patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip:
+        with patch.object(
+            self.generator, 'get_provd_net4_ip'
+        ) as provd_net4_ip, patch.object(
+            self.generator, 'get_provd_http_port'
+        ) as provd_http_port, patch.object(
+            self.generator, 'get_netiface_net4_ip'
+        ) as netiface_net4_ip:
             provd_net4_ip.return_value = '10.0.0.254'
             provd_http_port.return_value = None
             netiface_net4_ip.return_value = None
 
             value = self.generator.generate()
 
-        assert_config_equal(value, textwrap.dedent('''\
+        assert_config_equal(
+            value,
+            textwrap.dedent(
+                '''\
             general:
                 external_ip: 10.0.0.254
-        '''))
+        '''
+            ),
+        )
 
     @patch('wazo_confgend.plugins.provd_conf.session_scope')
     def test_net4_ip_in_netiface(self, session_scope):
         session_scope.__enter__ = Mock(return_value=Mock())
         session_scope.__exit__ = Mock(return_value=None)
 
-        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip,\
-                patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip,\
-                patch.object(self.generator, 'get_provd_http_port') as provd_http_port:
+        with patch.object(
+            self.generator, 'get_provd_net4_ip'
+        ) as provd_net4_ip, patch.object(
+            self.generator, 'get_netiface_net4_ip'
+        ) as netiface_net4_ip, patch.object(
+            self.generator, 'get_provd_http_port'
+        ) as provd_http_port:
             provd_net4_ip.return_value = None
             provd_http_port.return_value = None
             netiface_net4_ip.return_value = '10.0.0.250'
 
             value = self.generator.generate()
 
-        assert_config_equal(value, textwrap.dedent('''\
+        assert_config_equal(
+            value,
+            textwrap.dedent(
+                '''\
             general:
                 external_ip: 10.0.0.250
-        '''))
+        '''
+            ),
+        )
 
     @patch('wazo_confgend.plugins.provd_conf.session_scope')
     def test_complete_configuration(self, session_scope):
         session_scope.__enter__ = Mock(return_value=Mock())
         session_scope.__exit__ = Mock(return_value=None)
 
-        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip,\
-                patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip,\
-                patch.object(self.generator, 'get_provd_http_port') as provd_http_port:
+        with patch.object(
+            self.generator, 'get_provd_net4_ip'
+        ) as provd_net4_ip, patch.object(
+            self.generator, 'get_netiface_net4_ip'
+        ) as netiface_net4_ip, patch.object(
+            self.generator, 'get_provd_http_port'
+        ) as provd_http_port:
             provd_net4_ip.return_value = '10.0.0.254'
             provd_http_port.return_value = 8666
             netiface_net4_ip.return_value = '10.0.0.222'
 
             value = self.generator.generate()
 
-        assert_config_equal(value, textwrap.dedent('''\
+        assert_config_equal(
+            value,
+            textwrap.dedent(
+                '''\
             general:
                 external_ip: 10.0.0.254
                 http_port: 8666
-        '''))
+        '''
+            ),
+        )
 
     @patch('wazo_confgend.plugins.provd_conf.session_scope')
     def test_no_external_ip(self, session_scope):
         session_scope.__enter__ = Mock(return_value=Mock())
         session_scope.__exit__ = Mock(return_value=None)
 
-        with patch.object(self.generator, 'get_provd_net4_ip') as provd_net4_ip,\
-                patch.object(self.generator, 'get_provd_http_port') as provd_http_port,\
-                patch.object(self.generator, 'get_netiface_net4_ip') as netiface_net4_ip:
+        with patch.object(
+            self.generator, 'get_provd_net4_ip'
+        ) as provd_net4_ip, patch.object(
+            self.generator, 'get_provd_http_port'
+        ) as provd_http_port, patch.object(
+            self.generator, 'get_netiface_net4_ip'
+        ) as netiface_net4_ip:
             provd_net4_ip.return_value = None
             provd_http_port.return_value = None
             netiface_net4_ip.return_value = None

--- a/wazo_confgend/plugins/tests/test_provd_conf.py
+++ b/wazo_confgend/plugins/tests/test_provd_conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2019-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/template.py
+++ b/wazo_confgend/template.py
@@ -3,21 +3,21 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 from jinja2 import Environment
 from jinja2 import ChoiceLoader, PackageLoader, FileSystemLoader
 
 
 def new_template_helper():
-    loader = ChoiceLoader([
-        FileSystemLoader('/etc/wazo-confgend/templates'),
-        PackageLoader(__name__, 'templates'),
-    ])
+    loader = ChoiceLoader(
+        [
+            FileSystemLoader('/etc/wazo-confgend/templates'),
+            PackageLoader(__name__, 'templates'),
+        ]
+    )
     return TemplateHelper(loader)
 
 
 class TemplateHelper(object):
-
     def __init__(self, loader):
         self._env = Environment(loader=loader)
 
@@ -36,7 +36,6 @@ class TemplateHelper(object):
 
 
 class _Template(object):
-
     def __init__(self, jinja_template):
         self._jinja_template = jinja_template
 

--- a/wazo_confgend/template.py
+++ b/wazo_confgend/template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/template.py
+++ b/wazo_confgend/template.py
@@ -16,7 +16,7 @@ def new_template_helper():
     return TemplateHelper(loader)
 
 
-class TemplateHelper(object):
+class TemplateHelper:
     def __init__(self, loader):
         self._env = Environment(loader=loader)
 
@@ -34,7 +34,7 @@ class TemplateHelper(object):
         pass
 
 
-class _Template(object):
+class _Template:
     def __init__(self, jinja_template):
         self._jinja_template = jinja_template
 

--- a/wazo_confgend/template.py
+++ b/wazo_confgend/template.py
@@ -2,7 +2,7 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 from jinja2 import Environment
 from jinja2 import ChoiceLoader, PackageLoader, FileSystemLoader

--- a/wazo_confgend/template.py
+++ b/wazo_confgend/template.py
@@ -21,12 +21,12 @@ class TemplateHelper:
         self._env = Environment(loader=loader)
 
     def get_template(self, name):
-        filename = '{}.jinja'.format(name)
+        filename = f'{name}.jinja'
         return _Template(self._env.get_template(filename))
 
     def get_customizable_template(self, name, custom_part):
-        filename = '{}.jinja'.format(name)
-        filename_custom = '{}-{}.jinja'.format(name, custom_part)
+        filename = f'{name}.jinja'
+        filename_custom = f'{name}-{custom_part}.jinja'
         return _Template(self._env.select_template([filename_custom, filename]))
 
     def get_legacy_contexts_conf(self):

--- a/wazo_confgend/tests/__init__.py
+++ b/wazo_confgend/tests/__init__.py
@@ -1,3 +1,2 @@
-# -*- coding: utf-8 -*-
-# Copyright (C) 2013-2014 Avencall
+# Copyright 2013-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_confgend/tests/test_asterisk.py
+++ b/wazo_confgend/tests/test_asterisk.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/tests/test_asterisk.py
+++ b/wazo_confgend/tests/test_asterisk.py
@@ -22,11 +22,6 @@ class Test(unittest.TestCase):
         self.tpl_helper = Mock()
         self.asteriskFrontEnd = AsteriskFrontend(self._config, self.tpl_helper)
 
-    def test_encoding(self):
-        charset = ('ascii', 'US-ASCII',)
-        self.assertTrue(sys.getdefaultencoding() in charset,
-                        'Test should be run in ascii, in eclipse change run configuration common tab')
-
     @patch('xivo_dao.asterisk_conf_dao.find_agent_queue_skills_settings')
     def test_queueskills_conf(self, find_agent_queue_skills_settings):
         find_agent_queue_skills_settings.return_value = [

--- a/wazo_confgend/tests/test_asterisk.py
+++ b/wazo_confgend/tests/test_asterisk.py
@@ -4,7 +4,6 @@
 
 
 import unittest
-import sys
 
 from mock import patch, Mock
 

--- a/wazo_confgend/tests/test_asterisk.py
+++ b/wazo_confgend/tests/test_asterisk.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 import sys
 
@@ -14,7 +13,6 @@ from wazo_confgend.generators.tests.util import assert_config_equal
 
 
 class Test(unittest.TestCase):
-
     def setUp(self):
         self._config = {
             'templates': {'contextsconf': None},
@@ -32,7 +30,7 @@ class Test(unittest.TestCase):
             """
             [agent-1]
             test-skill = 10
-            """
+            """,
         )
         find_agent_queue_skills_settings.assert_called_once_with()
 
@@ -52,14 +50,21 @@ class Test(unittest.TestCase):
             [skillrule-2]
             rule = rule-3
             rule = rule-4
-            """
+            """,
         )
         find_queue_skillrule_settings.assert_called_once_with()
 
     @patch('xivo_dao.asterisk_conf_dao.find_queue_penalties_settings')
     def test_queuerules_conf(self, find_queue_penalties_settings):
         find_queue_penalties_settings.return_value = [
-            {'name': 'rule-1', 'seconds': 25, 'maxp_sign': '=', 'maxp_value': 2, 'minp_sign': '+', 'minp_value': 2},
+            {
+                'name': 'rule-1',
+                'seconds': 25,
+                'maxp_sign': '=',
+                'maxp_value': 2,
+                'minp_sign': '+',
+                'minp_value': 2,
+            },
             {'name': 'rule-2', 'seconds': 30, 'maxp_sign': None, 'minp_sign': None},
         ]
         assert_config_equal(
@@ -69,6 +74,6 @@ class Test(unittest.TestCase):
             penaltychange => 252,+2
             [rule-2]
             penaltychange => 30
-            """
+            """,
         )
         find_queue_penalties_settings.assert_called_once_with()

--- a/wazo_confgend/tests/test_asterisk.py
+++ b/wazo_confgend/tests/test_asterisk.py
@@ -2,7 +2,7 @@
 # Copyright 2011-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 import sys

--- a/wazo_confgend/tests/test_confgen.py
+++ b/wazo_confgend/tests/test_confgen.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/tests/test_confgen.py
+++ b/wazo_confgend/tests/test_confgen.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 import tempfile
 
@@ -20,7 +19,6 @@ from ..confgen import (
 
 
 class TestConfgen(unittest.TestCase):
-
     def setUp(self):
         self.factory = Mock()
         self.transport = Mock()
@@ -34,7 +32,9 @@ class TestConfgen(unittest.TestCase):
         self.protocol.dataReceived(cmd)
 
         self.factory.generate.assert_called_once_with('resource', 'filename.conf')
-        self.transport.write.assert_called_once_with(self.factory.generate.return_value.encode("utf-8"))
+        self.transport.write.assert_called_once_with(
+            self.factory.generate.return_value.encode("utf-8")
+        )
 
     def test_receive_command_no_result(self):
         self.factory.generate.return_value = None
@@ -50,12 +50,15 @@ class TestConfgen(unittest.TestCase):
 
         self.protocol.dataReceived(cmd)
 
-        self.factory.generate.assert_called_once_with('resource', 'filename.conf', 'arg1', 'arg2')
-        self.transport.write.assert_called_once_with(self.factory.generate.return_value.encode("utf-8"))
+        self.factory.generate.assert_called_once_with(
+            'resource', 'filename.conf', 'arg1', 'arg2'
+        )
+        self.transport.write.assert_called_once_with(
+            self.factory.generate.return_value.encode("utf-8")
+        )
 
 
 class TestConfgendFactory(unittest.TestCase):
-
     def setUp(self):
         config = {
             'templates': {'contextsconf': ''},

--- a/wazo_confgend/tests/test_confgen.py
+++ b/wazo_confgend/tests/test_confgen.py
@@ -29,16 +29,16 @@ class TestConfgen(unittest.TestCase):
         self.protocol.transport = self.transport
 
     def test_receive_command(self):
-        cmd = 'resource/filename.conf\n'
+        cmd = b'resource/filename.conf\n'
 
         self.protocol.dataReceived(cmd)
 
         self.factory.generate.assert_called_once_with('resource', 'filename.conf')
-        self.transport.write.assert_called_once_with(self.factory.generate.return_value)
+        self.transport.write.assert_called_once_with(self.factory.generate.return_value.encode("utf-8"))
 
     def test_receive_command_no_result(self):
         self.factory.generate.return_value = None
-        cmd = 'resource/filename.conf\n'
+        cmd = b'resource/filename.conf\n'
 
         self.protocol.dataReceived(cmd)
 
@@ -46,12 +46,12 @@ class TestConfgen(unittest.TestCase):
         self.transport.write.assert_not_called()
 
     def test_receive_with_arguments(self):
-        cmd = 'resource/filename.conf  arg1    arg2\n'
+        cmd = b'resource/filename.conf  arg1    arg2\n'
 
         self.protocol.dataReceived(cmd)
 
         self.factory.generate.assert_called_once_with('resource', 'filename.conf', 'arg1', 'arg2')
-        self.transport.write.assert_called_once_with(self.factory.generate.return_value)
+        self.transport.write.assert_called_once_with(self.factory.generate.return_value.encode("utf-8"))
 
 
 class TestConfgendFactory(unittest.TestCase):

--- a/wazo_confgend/tests/test_confgen.py
+++ b/wazo_confgend/tests/test_confgen.py
@@ -2,7 +2,7 @@
 # Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 import tempfile

--- a/wazo_confgend/tests/test_handler.py
+++ b/wazo_confgend/tests/test_handler.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # Copyright (C) 2016 Proformatique Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/wazo_confgend/tests/test_handler.py
+++ b/wazo_confgend/tests/test_handler.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 from hamcrest import assert_that
 from hamcrest import equal_to
 from hamcrest import calling
@@ -24,7 +23,6 @@ from ..handler import PluginHandlerFactory
 
 
 class TestCachedHandlerFactoryDecorator(TestCase):
-
     def test_that_two_gets_give_the_same_result(self):
         decorated = Mock()
         decorated.get.side_effect = [1, 2]
@@ -43,12 +41,13 @@ class TestCachedHandlerFactoryDecorator(TestCase):
 
         factory = CachedHandlerFactoryDecorator(decorated)
 
-        assert_that(calling(factory.get).with_args(s.resource, s.filename),
-                    raises(NoSuchHandler))
+        assert_that(
+            calling(factory.get).with_args(s.resource, s.filename),
+            raises(NoSuchHandler),
+        )
 
 
 class TestMultiHandlerFactory(TestCase):
-
     def test_given_no_fail_when_get_then_first_result_is_returned(self):
         factory1 = Mock()
         factory1.get.return_value = 1
@@ -78,12 +77,13 @@ class TestMultiHandlerFactory(TestCase):
         factory2.get.side_effect = NoSuchHandler()
         multi_factory = MultiHandlerFactory([factory1, factory2])
 
-        assert_that(calling(multi_factory.get).with_args(s.resource, s.filename),
-                    raises(NoSuchHandler))
+        assert_that(
+            calling(multi_factory.get).with_args(s.resource, s.filename),
+            raises(NoSuchHandler),
+        )
 
 
 class TestPluginHandlerFactory(TestCase):
-
     @patch('wazo_confgend.handler.driver')
     def test_given_no_driver_found_when_get_then_raise(self, stevedore_driver):
         stevedore_driver.DriverManager.side_effect = RuntimeError
@@ -92,8 +92,9 @@ class TestPluginHandlerFactory(TestCase):
         config = {'plugins': {'resource.filename': s.driver_name}}
         factory = PluginHandlerFactory(config, s.dependencies)
 
-        assert_that(calling(factory.get).with_args(resource, filename),
-                    raises(NoSuchHandler))
+        assert_that(
+            calling(factory.get).with_args(resource, filename), raises(NoSuchHandler)
+        )
 
     def test_given_no_config_when_get_then_raise(self):
         resource = 'resource'
@@ -101,8 +102,9 @@ class TestPluginHandlerFactory(TestCase):
         config = {'plugins': {}}
         factory = PluginHandlerFactory(config, s.dependencies)
 
-        assert_that(calling(factory.get).with_args(resource, filename),
-                    raises(NoSuchHandler))
+        assert_that(
+            calling(factory.get).with_args(resource, filename), raises(NoSuchHandler)
+        )
 
     @patch('wazo_confgend.handler.driver')
     def test_given_driver_found_when_get_then_return_handler(self, stevedore_driver):
@@ -118,15 +120,15 @@ class TestPluginHandlerFactory(TestCase):
 
 
 class TestFrontendHandlerFactory(TestCase):
-
     def test_given_no_frontend_found_when_get_then_raise(self):
         resource = 'resource'
         filename = 'filename'
         frontends = {}
         factory = FrontendHandlerFactory(frontends)
 
-        assert_that(calling(factory.get).with_args(resource, filename),
-                    raises(NoSuchHandler))
+        assert_that(
+            calling(factory.get).with_args(resource, filename), raises(NoSuchHandler)
+        )
 
     def test_given_frontend_has_no_callback_when_get_then_raise(self):
         resource = 'resource'
@@ -136,8 +138,9 @@ class TestFrontendHandlerFactory(TestCase):
         frontends = {'resource': frontend}
         factory = FrontendHandlerFactory(frontends)
 
-        assert_that(calling(factory.get).with_args(resource, filename),
-                    raises(NoSuchHandler))
+        assert_that(
+            calling(factory.get).with_args(resource, filename), raises(NoSuchHandler)
+        )
 
     def test_given_frontend_found_when_get_then_return_frontend(self):
         resource = 'resource'
@@ -152,7 +155,6 @@ class TestFrontendHandlerFactory(TestCase):
 
 
 class TestNullHandlerFactory(TestCase):
-
     def test_when_get_then_return_null_handler(self):
         factory = NullHandlerFactory()
 

--- a/wazo_confgend/tests/test_handler.py
+++ b/wazo_confgend/tests/test_handler.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2016 Proformatique Inc.
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 from hamcrest import assert_that
 from hamcrest import equal_to

--- a/wazo_confgend/tests/test_phoned.py
+++ b/wazo_confgend/tests/test_phoned.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/tests/test_phoned.py
+++ b/wazo_confgend/tests/test_phoned.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import unittest
 import yaml
 
@@ -14,7 +13,6 @@ from ..phoned import PhonedFrontend
 
 
 class TestDirdFrontend(unittest.TestCase):
-
     @patch('wazo_confgend.phoned.phone_access_dao')
     def test_config_yml(self, mock_phone_access_dao):
         authorized_subnets = ['169.254.0.0/16']
@@ -23,10 +21,6 @@ class TestDirdFrontend(unittest.TestCase):
 
         result = frontend.config_yml()
 
-        expected = {
-            'rest_api': {
-                'authorized_subnets': authorized_subnets
-            }
-        }
+        expected = {'rest_api': {'authorized_subnets': authorized_subnets}}
 
         assert_that(yaml.safe_load(result), equal_to(expected))

--- a/wazo_confgend/tests/test_phoned.py
+++ b/wazo_confgend/tests/test_phoned.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import unittest
 import yaml

--- a/wazo_confgend/tests/test_template.py
+++ b/wazo_confgend/tests/test_template.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/tests/test_template.py
+++ b/wazo_confgend/tests/test_template.py
@@ -2,7 +2,7 @@
 # Copyright 2016-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import os
 

--- a/wazo_confgend/tests/test_template.py
+++ b/wazo_confgend/tests/test_template.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import os
 
 from os.path import basename
@@ -16,7 +15,6 @@ from ..template import TemplateHelper
 
 
 class TestTemplateHelper(TestCase):
-
     def setUp(self):
         self.loader = PackageLoader('wazo_confgend', 'tests/templates')
         self.tpl_helper = TemplateHelper(self.loader)
@@ -29,7 +27,9 @@ class TestTemplateHelper(TestCase):
     def test_get_customizable_template(self):
         template = self.tpl_helper.get_customizable_template('foo', 'custom')
 
-        assert_that(basename(template._jinja_template.filename), equal_to('foo-custom.jinja'))
+        assert_that(
+            basename(template._jinja_template.filename), equal_to('foo-custom.jinja')
+        )
 
     def test_get_customizable_template_no_custom(self):
         template = self.tpl_helper.get_customizable_template('foo', 'mrgbl')
@@ -45,12 +45,16 @@ class TestTemplateHelper(TestCase):
 
 
 class TestIVRTemplate(TestCase):
-
     def setUp(self):
         cwd = os.path.dirname(os.path.abspath(__file__))
         self.template_path = os.path.abspath(
             os.path.join(
-                cwd, '..', 'templates', 'asterisk', 'extensions', 'ivr.jinja',
+                cwd,
+                '..',
+                'templates',
+                'asterisk',
+                'extensions',
+                'ivr.jinja',
             ),
         )
 

--- a/wazo_confgend/tests/test_wazo.py
+++ b/wazo_confgend/tests/test_wazo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/tests/test_wazo.py
+++ b/wazo_confgend/tests/test_wazo.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import yaml
 import unittest

--- a/wazo_confgend/tests/test_wazo.py
+++ b/wazo_confgend/tests/test_wazo.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import yaml
 import unittest
 
@@ -19,9 +18,10 @@ MockedInfo = namedtuple('MockedInfo', ['uuid'])
 
 
 class TestUUIDyml(unittest.TestCase):
-
-    @patch('wazo_confgend.wazo.infos_dao.get',
-           Mock(return_value=MockedInfo(uuid='sentinel-uuid')))
+    @patch(
+        'wazo_confgend.wazo.infos_dao.get',
+        Mock(return_value=MockedInfo(uuid='sentinel-uuid')),
+    )
     def test_uuid_yml(self):
         frontend = WazoFrontend()
 

--- a/wazo_confgend/wazo.py
+++ b/wazo_confgend/wazo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/wazo_confgend/wazo.py
+++ b/wazo_confgend/wazo.py
@@ -7,7 +7,7 @@ import yaml
 from xivo_dao.resources.infos import dao as infos_dao
 
 
-class WazoFrontend(object):
+class WazoFrontend:
     def uuid_yml(self):
         content = {'uuid': infos_dao.get().uuid}
         return yaml.safe_dump(content)

--- a/wazo_confgend/wazo.py
+++ b/wazo_confgend/wazo.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from __future__ import unicode_literals
+
 
 import yaml
 

--- a/wazo_confgend/wazo.py
+++ b/wazo_confgend/wazo.py
@@ -3,14 +3,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-
 import yaml
 
 from xivo_dao.resources.infos import dao as infos_dao
 
 
 class WazoFrontend(object):
-
     def uuid_yml(self):
         content = {'uuid': infos_dao.get().uuid}
         return yaml.safe_dump(content)

--- a/zuul.yaml
+++ b/zuul.yaml
@@ -1,5 +1,5 @@
 - project:
     templates:
       - wazo-tox-linters
-      - wazo-tox-py27
+      - wazo-tox-py37
       - debian-packaging-template


### PR DESCRIPTION
- [ ] Add relevant unit tests
- [x] test non-ascii unicode characters(e.g. accents in names, …)
  * modified a test with accentuated characters, though this adds little value as inputs/outputs are explicitly converted to/from utf-8 encoding. Integration testing to ensure asterisk utf-8 support would make more sense.
  
- [x] Refactoring (readability and maintainability)
  * formatting using black(resolves linter complaints too)

- [ ] Performance is not significantly decreased
  - [x] Not noticeably through manual testing
  - [ ] actual benchmarks: will be addressed in subsequent PR for automated integration tests

- [ ] Integration tests (see manual tests)
  * yet to be automated; started using a custom test docker env for testing things, 
    and bats(bash testing framework)

- [ ] Acceptance (e2e) tests

- [ ] manual tests: comparing new outputs with reference outputs for each conf
  - [x] personal dev stack: ok, except unsignificant diff for pjsip.conf (ordering of order-insensitive options within sections)
  - [x] wazo-test stack

NOTE FOR REVIEWERS: feel free to first look only at commits before the black formatting(9e437b400fa9c8b6f8e5b75409a91bb24a262ab3) in order to keep the noise down