### PR TITLE
moh: hardcode default class

### DIFF
--- a/wazo_confgend/plugins/tests/test_musiconhold.py
+++ b/wazo_confgend/plugins/tests/test_musiconhold.py
@@ -32,6 +32,10 @@ class TestConfBridgeConf(unittest.TestCase):
         assert_config_equal(
             value,
             '''
+            [default]
+            mode = files
+            directory = /var/lib/asterisk/moh/default
+
             [foo]
             mode = files
             directory = /var/lib/asterisk/moh/foo
@@ -51,6 +55,10 @@ class TestConfBridgeConf(unittest.TestCase):
         assert_config_equal(
             value,
             '''
+            [default]
+            mode = files
+            directory = /var/lib/asterisk/moh/default
+
             [bar]
             mode = custom
             application = /bin/false rrr
@@ -69,6 +77,10 @@ class TestConfBridgeConf(unittest.TestCase):
         assert_config_equal(
             value,
             '''
+            [default]
+            mode = files
+            directory = /var/lib/asterisk/moh/default
+
             [foo]
             mode = files
             directory = /var/lib/asterisk/moh/foo

--- a/wazo_confgend/templates/asterisk/musiconhold.jinja
+++ b/wazo_confgend/templates/asterisk/musiconhold.jinja
@@ -1,3 +1,6 @@
+[default]
+mode = files
+directory = /var/lib/asterisk/moh/default
 {% for moh in moh_list %}
 [{{ moh.name }}]
 mode = {{ moh.mode }}


### PR DESCRIPTION
Why:

* The database entries for the default MOH are corrupt (tenant UUID
  inexisting), we can't rely on them for now.
