### PR TITLE
pickup: add dialplan around the Pickup application

### DIFF
--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -20,7 +20,7 @@ DEFAULT_EXTENFEATURES = {
     'incallfilter': 'GoSub(incallfilter,s,1())',
     'phoneprogfunckey': 'GoSub(phoneprogfunckey,s,1(${EXTEN:0:4},${EXTEN:4}))',
     'phonestatus': 'GoSub(phonestatus,s,1())',
-    'pickup': 'Pickup(${EXTEN:2}%${CONTEXT}@PICKUPMARK)',
+    'pickup': 'GoSub(wazo-pickup,s,1(${EXTEN:2},${CONTEXT}))',
     'recsnd': 'GoSub(recsnd,s,1(wav))',
     'vmboxmsgslt': 'GoSub(vmboxmsg,s,1(${EXTEN:3}))',
     'vmboxpurgeslt': 'GoSub(vmboxpurge,s,1(${EXTEN:3}))',


### PR DESCRIPTION
calling Pickup here does not allow me to add logic for the dial_mobile scenario which is a stasis application that does not behave correctly with the Pickup application.

Depends-On: https://github.com/wazo-platform/xivo-config/pull/89