### PR TITLE
parking: remove default parking + global options

### DIFF
--- a/wazo_confgend/generators/res_parking.py
+++ b/wazo_confgend/generators/res_parking.py
@@ -1,8 +1,7 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
-from xivo_dao import asterisk_conf_dao
 from xivo_dao.resources.parking_lot import dao as parking_lot_dao
 
 from wazo_confgend.generators.util import AsteriskFileWriter
@@ -10,23 +9,11 @@ from wazo_confgend.generators.util import AsteriskFileWriter
 
 class ResParkingConf:
     def __init__(self):
-        self._settings = asterisk_conf_dao.find_parking_settings()
         self._parking_lots = parking_lot_dao.find_all_by()
 
     def generate(self, output):
         ast_file = AsteriskFileWriter(output)
-        self._generate_general(ast_file)
-        self._generate_default_parking_lot(ast_file)
         self._generate_parking_lots(ast_file)
-
-    def _generate_general(self, ast_file):
-        ast_file.write_section('general')
-        ast_file.write_options(self._settings['general_options'])
-
-    def _generate_default_parking_lot(self, ast_file):
-        for parking_lot in self._settings['parking_lots']:
-            ast_file.write_section(parking_lot['name'])
-            ast_file.write_options(parking_lot['options'])
 
     def _generate_parking_lots(self, ast_file):
         for parking_lot in self._parking_lots:

--- a/wazo_confgend/generators/tests/test_res_parking.py
+++ b/wazo_confgend/generators/tests/test_res_parking.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2015-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -10,51 +10,21 @@ from wazo_confgend.generators.tests.util import assert_generates_config
 
 
 class TestResParkingConf(unittest.TestCase):
-    def _new_conf(self, settings, parking_lots=None):
-        with patch('xivo_dao.asterisk_conf_dao.find_parking_settings'), patch(
-            'xivo_dao.resources.parking_lot.dao.find_all_by'
-        ):
+    def _new_conf(self, parking_lots=None):
+        with patch('xivo_dao.resources.parking_lot.dao.find_all_by'):
             conf = ResParkingConf()
-            conf._settings = settings
             conf._parking_lots = parking_lots or []
             return conf
 
-    def test_minimal_settings(self):
-        settings = {
-            'general_options': [],
-            'parking_lots': [],
-        }
-
-        res_parking_conf = self._new_conf(settings)
+    def test_no_settings(self):
+        res_parking_conf = self._new_conf()
 
         assert_generates_config(
             res_parking_conf,
-            '''
-            [general]
-        ''',
+            '',
         )
 
-    def test_settings(self):
-        settings = {
-            'general_options': [('parkeddynamic', 'no')],
-            'parking_lots': [{'name': 'default', 'options': [('parkext', '700')]}],
-        }
-
-        res_parking_conf = self._new_conf(settings)
-
-        assert_generates_config(
-            res_parking_conf,
-            '''
-            [general]
-            parkeddynamic = no
-
-            [default]
-            parkext = 700
-        ''',
-        )
-
-    def test_settings_with_parking_lots(self):
-        settings = {'general_options': [], 'parking_lots': []}
+    def test_parking_lots(self):
         parking_lots = [
             Mock(
                 id=1,
@@ -66,13 +36,11 @@ class TestResParkingConf(unittest.TestCase):
             )
         ]
 
-        res_parking_conf = self._new_conf(settings, parking_lots)
+        res_parking_conf = self._new_conf(parking_lots)
 
         assert_generates_config(
             res_parking_conf,
             '''
-            [general]
-
             [parkinglot-1]
             parkext = 800
             context = default
@@ -92,7 +60,6 @@ class TestResParkingConf(unittest.TestCase):
         )
 
     def test_parking_lots_with_none_values(self):
-        settings = {'general_options': [], 'parking_lots': []}
         parking_lots = [
             Mock(
                 id=1,
@@ -104,13 +71,11 @@ class TestResParkingConf(unittest.TestCase):
             )
         ]
 
-        res_parking_conf = self._new_conf(settings, parking_lots)
+        res_parking_conf = self._new_conf(parking_lots)
 
         assert_generates_config(
             res_parking_conf,
             '''
-            [general]
-
             [parkinglot-1]
             parkext = 800
             context = default


### PR DESCRIPTION
Why:

* replaced with multi-tenant parking lots