### PR TITLE
WAZO-3605-slow-extensions.conf

### DIFF
--- a/wazo_confgend/hints/adaptor.py
+++ b/wazo_confgend/hints/adaptor.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -28,8 +28,13 @@ class ProgfunckeyAdaptor(HintAdaptor):
 
 
 class UserAdaptor(HintAdaptor):
+    def __init__(self, dao):
+        super().__init__(dao)
+        self._hints = self.dao.user_hints()
+
     def generate(self, context):
-        for hint in self.dao.user_hints(context):
+        hints = self._hints.get(context) or []
+        for hint in hints:
             yield (hint.extension, hint.argument)
 
 
@@ -40,46 +45,72 @@ class UserSharedHintAdaptor(HintAdaptor):
 
 
 class ConferenceAdaptor(HintAdaptor):
+    def __init__(self, dao):
+        super().__init__(dao)
+        self._hints = self.dao.conference_hints()
+
     def generate(self, context):
-        for hint in self.dao.conference_hints(context):
+        hints = self._hints.get(context) or []
+        for hint in hints:
             yield (hint.extension, f'confbridge:{hint.conference_id}')
 
 
 class ForwardAdaptor(ProgfunckeyAdaptor):
+    def __init__(self, dao):
+        super().__init__(dao)
+        self._hints = self.dao.forward_hints()
+
     def find_hints(self, context):
-        return self.dao.forward_hints(context)
+        return self._hints.get(context) or []
 
     def progfunckey_arguments(self, hint):
         return [hint.user_id, hint.extension, hint.argument]
 
 
 class GroupMemberAdaptor(ProgfunckeyAdaptor):
+    def __init__(self, dao):
+        super().__init__(dao)
+        self._hints = self.dao.groupmember_hints()
+
     def find_hints(self, context):
-        return self.dao.groupmember_hints(context)
+        return self._hints.get(context) or []
 
     def progfunckey_arguments(self, hint):
         return [hint.user_id, hint.extension, hint.argument]
 
 
 class ServiceAdaptor(ProgfunckeyAdaptor):
+    def __init__(self, dao):
+        super().__init__(dao)
+        self._hints = self.dao.service_hints()
+
     def find_hints(self, context):
-        return self.dao.service_hints(context)
+        return self._hints.get(context) or []
 
     def progfunckey_arguments(self, hint):
         return [hint.user_id, hint.extension, hint.argument]
 
 
 class AgentAdaptor(ProgfunckeyAdaptor):
+    def __init__(self, dao):
+        super().__init__(dao)
+        self._hints = self.dao.agent_hints()
+
     def find_hints(self, context):
-        return self.dao.agent_hints(context)
+        return self._hints.get(context) or []
 
     def progfunckey_arguments(self, hint):
         return [hint.user_id, hint.extension, '*' + hint.argument]
 
 
 class CustomAdaptor(HintAdaptor):
+    def __init__(self, dao):
+        super().__init__(dao)
+        self._hints = self.dao.custom_hints()
+
     def generate(self, context):
-        for hint in self.dao.custom_hints(context):
+        hints = self._hints.get(context) or []
+        for hint in hints:
             try:
                 yield (hint.extension, f'Custom:{hint.extension}')
             except UnicodeEncodeError:
@@ -88,7 +119,12 @@ class CustomAdaptor(HintAdaptor):
 
 
 class BSFilterAdaptor(HintAdaptor):
+    def __init__(self, dao):
+        super().__init__(dao)
+        self._hints = self.dao.bsfilter_hints()
+
     def generate(self, context):
-        for hint in self.dao.bsfilter_hints(context):
+        hints = self._hints.get(context) or []
+        for hint in hints:
             extension = f'{hint.extension}{hint.argument}'
             yield (extension, f'Custom:{extension}')

--- a/wazo_confgend/hints/tests/test_adaptor.py
+++ b/wazo_confgend/hints/tests/test_adaptor.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2014-2024 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -31,15 +31,15 @@ class TestUserAdaptor(TestAdaptor):
     def setUp(self):
         super().setUp()
         self.dao = Mock()
-        self.dao.user_hints.return_value = [
-            Hint(user_id=42, extension='1000', argument='SIP/abcdef')
-        ]
+        self.dao.user_hints.return_value = {
+            CONTEXT: [Hint(user_id=42, extension='1000', argument='SIP/abcdef')],
+        }
 
         self.adaptor = UserAdaptor(self.dao)
 
     def test_adaptor_generates_user_hint(self):
         assert_that(self.adaptor.generate(CONTEXT), has_item(('1000', 'SIP/abcdef')))
-        self.dao.user_hints.assert_called_once_with(CONTEXT)
+        self.dao.user_hints.assert_called_once_with()
 
 
 class TestUserSharedHintsAdaptor(TestAdaptor):
@@ -76,14 +76,16 @@ class TestUserSharedHintsAdaptor(TestAdaptor):
 class TestConferenceAdaptor(TestAdaptor):
     def test_adaptor_generates_conference_hint(self):
         dao = Mock()
-        dao.conference_hints.return_value = [Hint(conference_id=1, extension='4000')]
+        dao.conference_hints.return_value = {
+            CONTEXT: [Hint(conference_id=1, extension='4000')]
+        }
 
         adaptor = ConferenceAdaptor(dao)
 
         assert_that(
             adaptor.generate(CONTEXT), contains_exactly(('4000', 'confbridge:1'))
         )
-        dao.conference_hints.assert_called_once_with(CONTEXT)
+        dao.conference_hints.assert_called_once_with()
 
 
 class TestForwardAdaptor(TestAdaptor):
@@ -92,29 +94,35 @@ class TestForwardAdaptor(TestAdaptor):
         self.dao = Mock()
         self.dao.progfunckey_extension.return_value = '*735'
 
-        self.adaptor = ForwardAdaptor(self.dao)
-
     def test_given_hint_with_argument_then_generates_progfunckey_with_argument(self):
-        self.dao.forward_hints.return_value = [
-            Hint(user_id=42, extension='*23', argument='1234')
-        ]
+        self.dao.forward_hints.return_value = {
+            CONTEXT: [
+                Hint(user_id=42, extension='*23', argument='1234'),
+            ],
+        }
+        self.adaptor = ForwardAdaptor(self.dao)
 
         assert_that(
             self.adaptor.generate(CONTEXT),
-            contains_exactly(('*73542***223*1234', 'Custom:*73542***223*1234')),
+            contains_exactly(
+                ('*73542***223*1234', 'Custom:*73542***223*1234'),
+            ),
         )
-        self.dao.forward_hints.assert_called_once_with(CONTEXT)
+        self.dao.forward_hints.assert_called_once_with()
 
     def test_given_hint_without_argument_then_generates_progfunckey_without_argument(
         self,
     ):
-        self.dao.forward_hints.return_value = [
-            Hint(user_id=42, extension='*23', argument=None)
-        ]
+        self.dao.forward_hints.return_value = {
+            CONTEXT: [Hint(user_id=42, extension='*23', argument=None)],
+        }
+        self.adaptor = ForwardAdaptor(self.dao)
 
         assert_that(
             self.adaptor.generate(CONTEXT),
-            contains_exactly(('*73542***223', 'Custom:*73542***223')),
+            contains_exactly(
+                ('*73542***223', 'Custom:*73542***223'),
+            ),
         )
 
 
@@ -122,9 +130,9 @@ class TestServiceAdaptor(TestAdaptor):
     def test_adaptor_generates_service_hint(self):
         dao = Mock()
         dao.progfunckey_extension.return_value = '*735'
-        dao.service_hints.return_value = [
-            Hint(user_id=42, extension='*26', argument=None)
-        ]
+        dao.service_hints.return_value = {
+            CONTEXT: [Hint(user_id=42, extension='*26', argument=None)],
+        }
 
         adaptor = ServiceAdaptor(dao)
 
@@ -132,16 +140,16 @@ class TestServiceAdaptor(TestAdaptor):
             adaptor.generate(CONTEXT),
             contains_exactly(('*73542***226', 'Custom:*73542***226')),
         )
-        dao.service_hints.assert_called_once_with(CONTEXT)
+        dao.service_hints.assert_called_once_with()
 
 
 class TestAgentAdaptor(TestAdaptor):
     def test_adaptor_generates_service_hint(self):
         dao = Mock()
         dao.progfunckey_extension.return_value = '*735'
-        dao.agent_hints.return_value = [
-            Hint(user_id=42, extension='*31', argument='56')
-        ]
+        dao.agent_hints.return_value = {
+            CONTEXT: [Hint(user_id=42, extension='*31', argument='56')],
+        }
 
         adaptor = AgentAdaptor(dao)
 
@@ -149,28 +157,30 @@ class TestAgentAdaptor(TestAdaptor):
             adaptor.generate(CONTEXT),
             contains_exactly(('*73542***231***356', 'Custom:*73542***231***356')),
         )
-        dao.agent_hints.assert_called_once_with(CONTEXT)
+        dao.agent_hints.assert_called_once_with()
 
 
 class TestCustomAdaptor(TestAdaptor):
     def test_adaptor_generates_custom_hint(self):
         dao = Mock()
-        dao.custom_hints.return_value = [
-            Hint(user_id=None, extension='1234', argument=None)
-        ]
+        dao.custom_hints.return_value = {
+            CONTEXT: [Hint(user_id=None, extension='1234', argument=None)],
+        }
 
         adaptor = CustomAdaptor(dao)
 
         assert_that(
             adaptor.generate(CONTEXT), contains_exactly(('1234', 'Custom:1234'))
         )
-        dao.custom_hints.assert_called_once_with(CONTEXT)
+        dao.custom_hints.assert_called_once_with()
 
     def test_that_non_ascii_characters_are_ignored(self):
         dao = Mock()
-        dao.custom_hints.return_value = [
-            Hint(user_id=None, extension='\xe9', argument=None),
-        ]
+        dao.custom_hints.return_value = {
+            CONTEXT: [
+                Hint(user_id=None, extension='\xe9', argument=None),
+            ],
+        }
 
         adaptor = CustomAdaptor(dao)
 
@@ -179,31 +189,31 @@ class TestCustomAdaptor(TestAdaptor):
         except Exception:
             raise AssertionError('Should not raise')
 
-        dao.custom_hints.assert_called_once_with(CONTEXT)
+        dao.custom_hints.assert_called_once_with()
 
 
 class TestBSFilterAdaptor(TestAdaptor):
     def test_adaptor_generates_bsfilter_hint(self):
         dao = Mock()
-        dao.bsfilter_hints.return_value = [
-            Hint(user_id=42, extension='*37', argument='12')
-        ]
+        dao.bsfilter_hints.return_value = {
+            CONTEXT: [Hint(user_id=42, extension='*37', argument='12')],
+        }
 
         adaptor = BSFilterAdaptor(dao)
 
         assert_that(
             adaptor.generate(CONTEXT), contains_exactly(('*3712', 'Custom:*3712'))
         )
-        dao.bsfilter_hints.assert_called_once_with(CONTEXT)
+        dao.bsfilter_hints.assert_called_once_with()
 
 
 class TestGroupMemberAdaptor(TestAdaptor):
     def test_adaptor_generates_groupmember_hint(self):
         dao = Mock()
         dao.progfunckey_extension.return_value = '*735'
-        dao.groupmember_hints.return_value = [
-            Hint(user_id=42, extension='*50', argument='18')
-        ]
+        dao.groupmember_hints.return_value = {
+            CONTEXT: [Hint(user_id=42, extension='*50', argument='18')],
+        }
 
         adaptor = GroupMemberAdaptor(dao)
 
@@ -211,4 +221,4 @@ class TestGroupMemberAdaptor(TestAdaptor):
             adaptor.generate(CONTEXT),
             contains_exactly(('*73542***250*18', 'Custom:*73542***250*18')),
         )
-        dao.groupmember_hints.assert_called_once_with(CONTEXT)
+        dao.groupmember_hints.assert_called_once_with()


### PR DESCRIPTION
the hints functions in the dao now return a dict of context/hints

this change makes it possible top query the DB only once for each hint type when generating the dialplan and reuse the same result for each context being generated.