### PR TITLE
parking: disable default parking lot

### DIFF
--- a/wazo_confgend/generators/res_parking.py
+++ b/wazo_confgend/generators/res_parking.py
@@ -12,7 +12,17 @@ class ResParkingConf:
 
     def generate(self, output):
         ast_file = AsteriskFileWriter(output)
+        self._generate_default_parking_lot(ast_file)
         self._generate_parking_lots(ast_file)
+
+    def _generate_default_parking_lot(self, ast_file):
+        section = 'default'
+        options = [
+            ('context', 'wazo-disabled'),
+        ]
+
+        ast_file.write_section(section)
+        ast_file.write_options(options)
 
     def _generate_parking_lots(self, ast_file):
         for parking_lot in self._parking_lots:

--- a/wazo_confgend/generators/tests/test_res_parking.py
+++ b/wazo_confgend/generators/tests/test_res_parking.py
@@ -21,7 +21,10 @@ class TestResParkingConf(unittest.TestCase):
 
         assert_generates_config(
             res_parking_conf,
-            '',
+            '''
+            [default]
+            context = wazo-disabled
+            ''',
         )
 
     def test_parking_lots(self):
@@ -41,6 +44,9 @@ class TestResParkingConf(unittest.TestCase):
         assert_generates_config(
             res_parking_conf,
             '''
+            [default]
+            context = wazo-disabled
+
             [parkinglot-1]
             parkext = 800
             context = default
@@ -76,6 +82,9 @@ class TestResParkingConf(unittest.TestCase):
         assert_generates_config(
             res_parking_conf,
             '''
+            [default]
+            context = wazo-disabled
+
             [parkinglot-1]
             parkext = 800
             context = default


### PR DESCRIPTION
Why:

* The default parking lot will override any extension between 700 and
  750