### PR TITLE
Dockerfile: include templates directory in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /usr/local/src/wazo-confgend
 RUN pip install incremental==17.5.0
 RUN pip install -r requirements.txt
 
+COPY MANIFEST.in /usr/local/src/wazo-confgend/
 COPY setup.py /usr/local/src/wazo-confgend/
 COPY bin /usr/local/src/wazo-confgend/bin
 COPY wazo_confgend /usr/local/src/wazo-confgend/wazo_confgend


### PR DESCRIPTION
why: without MANIFEST.in the templates directory was not included
Since bump of jinja2 version, an error was shown during the start of
the service