### PR TITLE
disable res_freeze_check

### DIFF
--- a/etc/wazo-confgend/config.yml
+++ b/etc/wazo-confgend/config.yml
@@ -95,6 +95,7 @@ enabled_asterisk_modules:
   res_statsd.so: false
   res_stun_monitor.so: false
   res_xmpp.so: false
+  res_freeze_check.so: false
 
 # Plugins to use to generate the configuration files
 plugins:


### PR DESCRIPTION
we have a bug that prevent asterisk from start when starting res_freeze_check