### PR TITLE
Revert "disable res_freeze_check"

### DIFF
--- a/etc/wazo-confgend/config.yml
+++ b/etc/wazo-confgend/config.yml
@@ -95,7 +95,6 @@ enabled_asterisk_modules:
   res_statsd.so: false
   res_stun_monitor.so: false
   res_xmpp.so: false
-  res_freeze_check.so: false
 
 # Plugins to use to generate the configuration files
 plugins:


### PR DESCRIPTION
Reverts wazo-platform/wazo-confgend#122
This should be done after merging the res-freeze-check fix: https://github.com/wazo-platform/xivo-res-freeze-check/pull/14