### PR TITLE
[ITEM-205] extensionsconf: remove calllistening generation

### DIFF
--- a/wazo_confgend/generators/extensionsconf.py
+++ b/wazo_confgend/generators/extensionsconf.py
@@ -1,4 +1,4 @@
-# Copyright 2011-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2011-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import configparser
@@ -34,7 +34,6 @@ DEFAULT_EXTENFEATURES = {
     'agentstaticlogtoggle': 'GoSub(agentstaticlogtoggle,s,1(${EXTEN:3}))',
     'bsfilter': 'GoSub(bsfilter,s,1(${EXTEN:3}))',
     'meetingjoin': 'GoSub(meetingjoin,s,1(${EXTEN:3}))',
-    'calllistening': 'GoSub(calllistening,s,1())',
     'callrecord': 'GoSub(callrecord,s,1() )',
     'directoryaccess': 'Directory(${CONTEXT})',
     'enablednd': 'GoSub(enablednd,s,1())',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: removes a single dialplan feature mapping (`calllistening`) from `DEFAULT_EXTENFEATURES`, so the only impact is that this feature will no longer be emitted in generated `extensions.conf` if configured.
> 
> **Overview**
> Stops generating the `calllistening` dialplan entry by removing it from `DEFAULT_EXTENFEATURES` in `extensionsconf.py`, so `find_exten_xivofeatures_setting()` will no longer emit an `exten` for that feature.
> 
> Also updates the copyright header year to 2026.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d79e653554fe5dd744155862cf6b5b1a573e7aed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->